### PR TITLE
Support endpoints without application/json bodies

### DIFF
--- a/generator/gen-client.ts
+++ b/generator/gen-client.ts
@@ -153,7 +153,7 @@ function schemaToType(schema: Schema, opts: SchemaToTypeOpts = {}) {
 function contentRef(o: Schema | OpenAPIV3.RequestBodyObject | undefined) {
   return o &&
     "content" in o &&
-    o.content?.["application/json"].schema &&
+    o.content?.["application/json"]?.schema &&
     "$ref" in o.content["application/json"].schema
     ? o.content["application/json"].schema.$ref
     : null;


### PR DESCRIPTION
Since https://github.com/oxidecomputer/dropshot/pull/363 landed, API endpoints may have body types other than `application/json`. This patch allows the TypeScript client generator to handle such endpoints by ignoring them (rather than failing in generation).