### PR TITLE
Safety test for hard-coded `Error` schema

### DIFF
--- a/client/Api.ts
+++ b/client/Api.ts
@@ -1,12 +1,14 @@
 /* eslint-disable */
 
-import { HttpClient, RequestParams } from "./http-client";
+import type { RequestParams } from "./http-client";
+import { HttpClient } from "./http-client";
 
 export type {
   ApiConfig,
   ApiError,
   ApiResult,
   ClientError,
+  ErrorBody,
   ErrorResult,
 } from "./http-client";
 
@@ -247,15 +249,6 @@ export type Distribution = {
    * The version of the distribution (e.g. "3.10" or "18.04")
    */
   version: string;
-};
-
-/**
- * Error information from a response.
- */
-export type ErrorBody = {
-  errorCode?: string | null;
-  message: string;
-  requestId: string;
 };
 
 export type ExternalIp = {

--- a/client/http-client.ts
+++ b/client/http-client.ts
@@ -31,7 +31,7 @@ export type ApiSuccess<Data> = {
 // HACK: this has to match what comes from the API in the `Error` schema. We put
 // our own copy here so we can test this file statically without generating
 // anything
-type ErrorBody = {
+export type ErrorBody = {
   errorCode?: string | null;
   message: string;
   requestId: string;

--- a/generator/base/http-client.ts
+++ b/generator/base/http-client.ts
@@ -31,7 +31,7 @@ export type ApiSuccess<Data> = {
 // HACK: this has to match what comes from the API in the `Error` schema. We put
 // our own copy here so we can test this file statically without generating
 // anything
-type ErrorBody = {
+export type ErrorBody = {
   errorCode?: string | null;
   message: string;
   requestId: string;


### PR DESCRIPTION
Pretty well explained in the comments, but basically we skip generating the `Error` schema form the spec in favor of our hard-coded one, but we also want to make sure to error out if the one in the spec has changed from what we think it is.