### PR TITLE
Drop nullability

### DIFF
--- a/client/Api.ts
+++ b/client/Api.ts
@@ -216,12 +216,12 @@ export type Disk = {
   devicePath: string;
   /** unique, immutable, system-controlled identifier for each resource */
   id: string;
-  imageId?: string | null;
+  imageId?: string;
   /** unique, mutable, user-controlled identifier for each resource */
   name: Name;
   projectId: string;
   size: ByteCount;
-  snapshotId?: string | null;
+  snapshotId?: string;
   state: DiskState;
   /** timestamp when this resource was created */
   timeCreated: Date;
@@ -270,7 +270,7 @@ export type DiskResultsPage = {
   /** list of items on this page of results */
   items: Disk[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -293,7 +293,7 @@ export type ExternalIp = { ip: string; kind: IpKind };
 /**
  * Parameters for creating an external IP address for instances.
  */
-export type ExternalIpCreate = { poolName?: Name | null; type: "ephemeral" };
+export type ExternalIpCreate = { poolName?: Name; type: "ephemeral" };
 
 /**
  * A single page of results
@@ -302,7 +302,7 @@ export type ExternalIpResultsPage = {
   /** list of items on this page of results */
   items: ExternalIp[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -357,7 +357,7 @@ export type GlobalImage = {
   /** human-readable free-form text about a resource */
   description: string;
   /** Hash of the image contents, if applicable */
-  digest?: Digest | null;
+  digest?: Digest;
   /** Image distribution */
   distribution: string;
   /** unique, immutable, system-controlled identifier for each resource */
@@ -371,7 +371,7 @@ export type GlobalImage = {
   /** timestamp when this resource was last modified */
   timeModified: Date;
   /** URL source of this image, if any */
-  url?: string | null;
+  url?: string;
   /** Image version */
   version: string;
 };
@@ -406,7 +406,7 @@ export type GlobalImageResultsPage = {
   /** list of items on this page of results */
   items: GlobalImage[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 export type IdentityProviderType = "saml";
@@ -436,7 +436,7 @@ export type IdentityProviderResultsPage = {
   /** list of items on this page of results */
   items: IdentityProvider[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 export type IdpMetadataSource =
@@ -452,7 +452,7 @@ export type Image = {
   /** human-readable free-form text about a resource */
   description: string;
   /** Hash of the image contents, if applicable */
-  digest?: Digest | null;
+  digest?: Digest;
   /** unique, immutable, system-controlled identifier for each resource */
   id: string;
   /** unique, mutable, user-controlled identifier for each resource */
@@ -466,9 +466,9 @@ export type Image = {
   /** timestamp when this resource was last modified */
   timeModified: Date;
   /** URL source of this image, if any */
-  url?: string | null;
+  url?: string;
   /** Version of this, if any */
-  version?: string | null;
+  version?: string;
 };
 
 /**
@@ -490,7 +490,7 @@ export type ImageResultsPage = {
   /** list of items on this page of results */
   items: Image[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -578,7 +578,7 @@ export type InstanceDiskAttachment =
 export type NetworkInterfaceCreate = {
   description: string;
   /** The IP address for the interface. One will be auto-assigned if not provided. */
-  ip?: string | null;
+  ip?: string;
   name: Name;
   /** The VPC Subnet in which to create the interface. */
   subnetName: Name;
@@ -634,7 +634,7 @@ export type InstanceResultsPage = {
   /** list of items on this page of results */
   items: Instance[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -673,7 +673,7 @@ export type IpPool = {
   id: string;
   /** unique, mutable, user-controlled identifier for each resource */
   name: Name;
-  projectId?: string | null;
+  projectId?: string;
   /** timestamp when this resource was created */
   timeCreated: Date;
   /** timestamp when this resource was last modified */
@@ -717,7 +717,7 @@ export type IpPoolRangeResultsPage = {
   /** list of items on this page of results */
   items: IpPoolRange[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -727,13 +727,13 @@ export type IpPoolResultsPage = {
   /** list of items on this page of results */
   items: IpPool[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
  * Parameters for updating an IP Pool
  */
-export type IpPoolUpdate = { description?: string | null; name?: Name | null };
+export type IpPoolUpdate = { description?: string; name?: Name };
 
 /**
  * A range of IP ports
@@ -761,7 +761,7 @@ export type MeasurementResultsPage = {
   /** list of items on this page of results */
   items: Measurement[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -799,7 +799,7 @@ export type NetworkInterfaceResultsPage = {
   /** list of items on this page of results */
   items: NetworkInterface[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -808,8 +808,8 @@ export type NetworkInterfaceResultsPage = {
  * Note that modifying IP addresses for an interface is not yet supported, a new interface must be created instead.
  */
 export type NetworkInterfaceUpdate = {
-  description?: string | null;
-  name?: Name | null;
+  description?: string;
+  name?: Name;
   /** Make a secondary interface the instance's primary interface.
 
 If applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.
@@ -853,7 +853,7 @@ export type OrganizationResultsPage = {
   /** list of items on this page of results */
   items: Organization[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 export type OrganizationRole = "admin" | "collaborator" | "viewer";
@@ -882,10 +882,7 @@ export type OrganizationRolePolicy = {
 /**
  * Updateable properties of an {@link Organization}
  */
-export type OrganizationUpdate = {
-  description?: string | null;
-  name?: Name | null;
-};
+export type OrganizationUpdate = { description?: string; name?: Name };
 
 /**
  * Client view of a {@link Project}
@@ -916,7 +913,7 @@ export type ProjectResultsPage = {
   /** list of items on this page of results */
   items: Project[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 export type ProjectRole = "admin" | "collaborator" | "viewer";
@@ -945,7 +942,7 @@ export type ProjectRolePolicy = {
 /**
  * Updateable properties of a {@link Project}
  */
-export type ProjectUpdate = { description?: string | null; name?: Name | null };
+export type ProjectUpdate = { description?: string; name?: Name };
 
 /**
  * Client view of an {@link Rack}
@@ -966,7 +963,7 @@ export type RackResultsPage = {
   /** list of items on this page of results */
   items: Rack[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -988,7 +985,7 @@ export type RoleResultsPage = {
   /** list of items on this page of results */
   items: Role[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -1083,16 +1080,16 @@ export type RouterRouteResultsPage = {
   /** list of items on this page of results */
   items: RouterRoute[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
  * Updateable properties of a {@link RouterRoute}
  */
 export type RouterRouteUpdateParams = {
-  description?: string | null;
+  description?: string;
   destination: RouteDestination;
-  name?: Name | null;
+  name?: Name;
   target: RouteTarget;
 };
 
@@ -1117,7 +1114,7 @@ export type SagaResultsPage = {
   /** list of items on this page of results */
   items: Saga[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -1135,7 +1132,7 @@ export type SamlIdentityProvider = {
   /** unique, mutable, user-controlled identifier for each resource */
   name: Name;
   /** optional request signing public certificate (base64 encoded der file) */
-  publicCert?: string | null;
+  publicCert?: string;
   /** service provider endpoint where the idp should send log out requests */
   sloUrl: string;
   /** sp's client id */
@@ -1156,14 +1153,14 @@ export type SamlIdentityProviderCreate = {
   acsUrl: string;
   description: string;
   /** If set, SAML attributes with this name will be considered to denote a user's group membership, where the attribute value(s) should be a comma-separated list of group names. */
-  groupAttributeName?: string | null;
+  groupAttributeName?: string;
   /** idp's entity id */
   idpEntityId: string;
   /** the source of an identity provider metadata descriptor */
   idpMetadataSource: IdpMetadataSource;
   name: Name;
   /** optional request signing key pair */
-  signingKeypair?: DerEncodedKeyPair | null;
+  signingKeypair?: DerEncodedKeyPair;
   /** service provider endpoint where the idp should send log out requests */
   sloUrl: string;
   /** sp's client id */
@@ -1208,7 +1205,7 @@ export type SiloCreate = {
   /** If set, this group will be created during Silo creation and granted the "Silo Admin" role. Identity providers can assert that users belong to this group and those users can log in and further initialize the Silo.
 
 Note that if configuring a SAML based identity provider, group_attribute_name must be set for users to be considered part of a group. See [`SamlIdentityProviderCreate`] for more information. */
-  adminGroupName?: string | null;
+  adminGroupName?: string;
   description: string;
   discoverable: boolean;
   identityMode: SiloIdentityMode;
@@ -1222,7 +1219,7 @@ export type SiloResultsPage = {
   /** list of items on this page of results */
   items: Silo[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 export type SiloRole = "admin" | "collaborator" | "viewer";
@@ -1268,7 +1265,7 @@ export type SledResultsPage = {
   /** list of items on this page of results */
   items: Sled[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 export type SnapshotState = "creating" | "ready" | "faulted" | "destroyed";
@@ -1310,7 +1307,7 @@ export type SnapshotResultsPage = {
   /** list of items on this page of results */
   items: Snapshot[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 export type SpoofLoginBody = { username: string };
@@ -1352,7 +1349,7 @@ export type SshKeyResultsPage = {
   /** list of items on this page of results */
   items: SshKey[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -1381,7 +1378,7 @@ export type TimeseriesSchemaResultsPage = {
   /** list of items on this page of results */
   items: TimeseriesSchema[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -1416,7 +1413,7 @@ export type UserBuiltinResultsPage = {
   /** list of items on this page of results */
   items: UserBuiltin[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -1426,7 +1423,7 @@ export type UserResultsPage = {
   /** list of items on this page of results */
   items: User[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
@@ -1462,7 +1459,7 @@ export type VpcCreate = {
   /** The IPv6 prefix for this VPC.
 
 All IPv6 subnets created from this VPC must be taken from this range, which sould be a Unique Local Address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix. */
-  ipv6Prefix?: Ipv6Net | null;
+  ipv6Prefix?: Ipv6Net;
   name: Name;
 };
 
@@ -1495,11 +1492,11 @@ export type VpcFirewallRuleProtocol = "TCP" | "UDP" | "ICMP";
  */
 export type VpcFirewallRuleFilter = {
   /** If present, the sources (if incoming) or destinations (if outgoing) this rule applies to. */
-  hosts?: VpcFirewallRuleHostFilter[] | null;
+  hosts?: VpcFirewallRuleHostFilter[];
   /** If present, the destination ports this rule applies to. */
-  ports?: L4PortRange[] | null;
+  ports?: L4PortRange[];
   /** If present, the networking protocols this rule applies to. */
-  protocols?: VpcFirewallRuleProtocol[] | null;
+  protocols?: VpcFirewallRuleProtocol[];
 };
 
 export type VpcFirewallRuleStatus = "disabled" | "enabled";
@@ -1588,7 +1585,7 @@ export type VpcResultsPage = {
   /** list of items on this page of results */
   items: Vpc[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 export type VpcRouterKind = "system" | "custom";
@@ -1624,16 +1621,13 @@ export type VpcRouterResultsPage = {
   /** list of items on this page of results */
   items: VpcRouter[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
  * Updateable properties of a {@link VpcRouter}
  */
-export type VpcRouterUpdate = {
-  description?: string | null;
-  name?: Name | null;
-};
+export type VpcRouterUpdate = { description?: string; name?: Name };
 
 /**
  * A VPC subnet represents a logical grouping for instances that allows network traffic between them, within a IPv4 subnetwork or optionall an IPv6 subnetwork.
@@ -1669,7 +1663,7 @@ It must be allocated from an RFC 1918 private address range, and must not overla
   /** The IPv6 address range for this subnet.
 
 It must be allocated from the RFC 4193 Unique Local Address range, with the prefix equal to the parent VPC's prefix. A random `/64` block will be assigned if one is not provided. It must not overlap with any existing subnet in the VPC. */
-  ipv6Block?: Ipv6Net | null;
+  ipv6Block?: Ipv6Net;
   name: Name;
 };
 
@@ -1680,25 +1674,18 @@ export type VpcSubnetResultsPage = {
   /** list of items on this page of results */
   items: VpcSubnet[];
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string | null;
+  nextPage?: string;
 };
 
 /**
  * Updateable properties of a {@link VpcSubnet}
  */
-export type VpcSubnetUpdate = {
-  description?: string | null;
-  name?: Name | null;
-};
+export type VpcSubnetUpdate = { description?: string; name?: Name };
 
 /**
  * Updateable properties of a {@link Vpc}
  */
-export type VpcUpdate = {
-  description?: string | null;
-  dnsName?: Name | null;
-  name?: Name | null;
-};
+export type VpcUpdate = { description?: string; dnsName?: Name; name?: Name };
 
 /**
  * Supported set of sort modes for scanning by name or id
@@ -1799,7 +1786,7 @@ export interface LogoutParams {}
 
 export interface OrganizationListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameOrIdSortMode;
 }
 
@@ -1827,7 +1814,7 @@ export interface OrganizationPolicyUpdateParams {
 
 export interface ProjectListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameOrIdSortMode;
   orgName: Name;
 }
@@ -1853,7 +1840,7 @@ export interface ProjectDeleteParams {
 
 export interface DiskListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
   orgName: Name;
   projectName: Name;
@@ -1883,13 +1870,13 @@ export interface DiskMetricsListParams {
   projectName: Name;
   endTime?: Date;
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   startTime?: Date;
 }
 
 export interface ImageListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
   orgName: Name;
   projectName: Name;
@@ -1914,7 +1901,7 @@ export interface ImageDeleteParams {
 
 export interface InstanceListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
   orgName: Name;
   projectName: Name;
@@ -1939,7 +1926,7 @@ export interface InstanceDeleteParams {
 
 export interface InstanceDiskListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
   instanceName: Name;
   orgName: Name;
@@ -1972,7 +1959,7 @@ export interface InstanceMigrateParams {
 
 export interface InstanceNetworkInterfaceListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
   instanceName: Name;
   orgName: Name;
@@ -2045,7 +2032,7 @@ export interface ProjectPolicyUpdateParams {
 
 export interface SnapshotListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
   orgName: Name;
   projectName: Name;
@@ -2070,7 +2057,7 @@ export interface SnapshotDeleteParams {
 
 export interface VpcListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
   orgName: Name;
   projectName: Name;
@@ -2113,7 +2100,7 @@ export interface VpcFirewallRulesUpdateParams {
 
 export interface VpcRouterListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
   orgName: Name;
   projectName: Name;
@@ -2149,7 +2136,7 @@ export interface VpcRouterDeleteParams {
 
 export interface VpcRouterRouteListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
   orgName: Name;
   projectName: Name;
@@ -2190,7 +2177,7 @@ export interface VpcRouterRouteDeleteParams {
 
 export interface VpcSubnetListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
   orgName: Name;
   projectName: Name;
@@ -2226,7 +2213,7 @@ export interface VpcSubnetDeleteParams {
 
 export interface VpcSubnetListNetworkInterfacesParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
   orgName: Name;
   projectName: Name;
@@ -2240,7 +2227,7 @@ export interface PolicyUpdateParams {}
 
 export interface RoleListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
 }
 
 export interface RoleViewParams {
@@ -2251,7 +2238,7 @@ export interface SessionMeParams {}
 
 export interface SessionSshkeyListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
 }
 
@@ -2279,7 +2266,7 @@ export interface SiloViewByIdParams {
 
 export interface RackListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: IdSortMode;
 }
 
@@ -2289,7 +2276,7 @@ export interface RackViewParams {
 
 export interface SledListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: IdSortMode;
 }
 
@@ -2299,7 +2286,7 @@ export interface SledViewParams {
 
 export interface SystemImageListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
 }
 
@@ -2315,7 +2302,7 @@ export interface SystemImageDeleteParams {
 
 export interface IpPoolListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameOrIdSortMode;
 }
 
@@ -2336,7 +2323,7 @@ export interface IpPoolDeleteParams {
 export interface IpPoolRangeListParams {
   poolName: Name;
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
 }
 
 export interface IpPoolRangeAddParams {
@@ -2354,7 +2341,7 @@ export interface IpPoolServiceViewParams {
 export interface IpPoolServiceRangeListParams {
   rackId: string;
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
 }
 
 export interface IpPoolServiceRangeAddParams {
@@ -2371,7 +2358,7 @@ export interface SystemPolicyUpdateParams {}
 
 export interface SagaListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: IdSortMode;
 }
 
@@ -2381,7 +2368,7 @@ export interface SagaViewParams {
 
 export interface SiloListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameOrIdSortMode;
 }
 
@@ -2398,7 +2385,7 @@ export interface SiloDeleteParams {
 export interface SiloIdentityProviderListParams {
   siloName: Name;
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
 }
 
@@ -2423,7 +2410,7 @@ export interface UpdatesRefreshParams {}
 
 export interface SystemUserListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: NameSortMode;
 }
 
@@ -2433,12 +2420,12 @@ export interface SystemUserViewParams {
 
 export interface TimeseriesSchemaGetParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
 }
 
 export interface UserListParams {
   limit?: number;
-  pageToken?: string | null;
+  pageToken?: string;
   sortBy?: IdSortMode;
 }
 

--- a/client/validate.ts
+++ b/client/validate.ts
@@ -261,11 +261,11 @@ export const Disk = z.preprocess(
     description: z.string(),
     devicePath: z.string(),
     id: z.string().uuid(),
-    imageId: z.string().uuid().nullable().optional(),
+    imageId: z.string().uuid().optional(),
     name: Name,
     projectId: z.string().uuid(),
     size: ByteCount,
-    snapshotId: z.string().uuid().nullable().optional(),
+    snapshotId: z.string().uuid().optional(),
     state: DiskState,
     timeCreated: DateType,
     timeModified: DateType,
@@ -311,7 +311,7 @@ export const DiskIdentifier = z.preprocess(
  */
 export const DiskResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Disk.array(), nextPage: z.string().nullable().optional() })
+  z.object({ items: Disk.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -352,10 +352,7 @@ export const ExternalIp = z.preprocess(
  */
 export const ExternalIpCreate = z.preprocess(
   processResponseBody,
-  z.object({
-    poolName: Name.nullable().optional(),
-    type: z.enum(["ephemeral"]),
-  })
+  z.object({ poolName: Name.optional(), type: z.enum(["ephemeral"]) })
 );
 
 /**
@@ -363,10 +360,7 @@ export const ExternalIpCreate = z.preprocess(
  */
 export const ExternalIpResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: ExternalIp.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: ExternalIp.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -438,14 +432,14 @@ export const GlobalImage = z.preprocess(
   z.object({
     blockSize: ByteCount,
     description: z.string(),
-    digest: Digest.nullable().optional(),
+    digest: Digest.optional(),
     distribution: z.string(),
     id: z.string().uuid(),
     name: Name,
     size: ByteCount,
     timeCreated: DateType,
     timeModified: DateType,
-    url: z.string().nullable().optional(),
+    url: z.string().optional(),
     version: z.string(),
   })
 );
@@ -481,10 +475,7 @@ export const GlobalImageCreate = z.preprocess(
  */
 export const GlobalImageResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: GlobalImage.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: GlobalImage.array(), nextPage: z.string().optional() })
 );
 
 export const IdentityProviderType = z.preprocess(
@@ -512,10 +503,7 @@ export const IdentityProvider = z.preprocess(
  */
 export const IdentityProviderResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: IdentityProvider.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: IdentityProvider.array(), nextPage: z.string().optional() })
 );
 
 export const IdpMetadataSource = z.preprocess(
@@ -534,15 +522,15 @@ export const Image = z.preprocess(
   z.object({
     blockSize: ByteCount,
     description: z.string(),
-    digest: Digest.nullable().optional(),
+    digest: Digest.optional(),
     id: z.string().uuid(),
     name: Name,
     projectId: z.string().uuid(),
     size: ByteCount,
     timeCreated: DateType,
     timeModified: DateType,
-    url: z.string().nullable().optional(),
-    version: z.string().nullable().optional(),
+    url: z.string().optional(),
+    version: z.string().optional(),
   })
 );
 
@@ -564,7 +552,7 @@ export const ImageCreate = z.preprocess(
  */
 export const ImageResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Image.array(), nextPage: z.string().nullable().optional() })
+  z.object({ items: Image.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -640,7 +628,7 @@ export const NetworkInterfaceCreate = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    ip: z.string().nullable().optional(),
+    ip: z.string().optional(),
     name: Name,
     subnetName: Name,
     vpcName: Name,
@@ -696,10 +684,7 @@ export const InstanceMigrate = z.preprocess(
  */
 export const InstanceResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Instance.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Instance.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -755,7 +740,7 @@ export const IpPool = z.preprocess(
     description: z.string(),
     id: z.string().uuid(),
     name: Name,
-    projectId: z.string().uuid().nullable().optional(),
+    projectId: z.string().uuid().optional(),
     timeCreated: DateType,
     timeModified: DateType,
   })
@@ -811,10 +796,7 @@ export const IpPoolRange = z.preprocess(
  */
 export const IpPoolRangeResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: IpPoolRange.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: IpPoolRange.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -822,10 +804,7 @@ export const IpPoolRangeResultsPage = z.preprocess(
  */
 export const IpPoolResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: IpPool.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: IpPool.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -833,10 +812,7 @@ export const IpPoolResultsPage = z.preprocess(
  */
 export const IpPoolUpdate = z.preprocess(
   processResponseBody,
-  z.object({
-    description: z.string().nullable().optional(),
-    name: Name.nullable().optional(),
-  })
+  z.object({ description: z.string().optional(), name: Name.optional() })
 );
 
 /**
@@ -880,10 +856,7 @@ export const Measurement = z.preprocess(
  */
 export const MeasurementResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Measurement.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Measurement.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -911,10 +884,7 @@ export const NetworkInterface = z.preprocess(
  */
 export const NetworkInterfaceResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: NetworkInterface.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: NetworkInterface.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -925,8 +895,8 @@ export const NetworkInterfaceResultsPage = z.preprocess(
 export const NetworkInterfaceUpdate = z.preprocess(
   processResponseBody,
   z.object({
-    description: z.string().nullable().optional(),
-    name: Name.nullable().optional(),
+    description: z.string().optional(),
+    name: Name.optional(),
     primary: z.boolean().default(false).optional(),
   })
 );
@@ -965,10 +935,7 @@ export const OrganizationCreate = z.preprocess(
  */
 export const OrganizationResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Organization.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Organization.array(), nextPage: z.string().optional() })
 );
 
 export const OrganizationRole = z.preprocess(
@@ -1005,10 +972,7 @@ export const OrganizationRolePolicy = z.preprocess(
  */
 export const OrganizationUpdate = z.preprocess(
   processResponseBody,
-  z.object({
-    description: z.string().nullable().optional(),
-    name: Name.nullable().optional(),
-  })
+  z.object({ description: z.string().optional(), name: Name.optional() })
 );
 
 /**
@@ -1039,10 +1003,7 @@ export const ProjectCreate = z.preprocess(
  */
 export const ProjectResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Project.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Project.array(), nextPage: z.string().optional() })
 );
 
 export const ProjectRole = z.preprocess(
@@ -1079,10 +1040,7 @@ export const ProjectRolePolicy = z.preprocess(
  */
 export const ProjectUpdate = z.preprocess(
   processResponseBody,
-  z.object({
-    description: z.string().nullable().optional(),
-    name: Name.nullable().optional(),
-  })
+  z.object({ description: z.string().optional(), name: Name.optional() })
 );
 
 /**
@@ -1102,7 +1060,7 @@ export const Rack = z.preprocess(
  */
 export const RackResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Rack.array(), nextPage: z.string().nullable().optional() })
+  z.object({ items: Rack.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -1131,7 +1089,7 @@ export const Role = z.preprocess(
  */
 export const RoleResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Role.array(), nextPage: z.string().nullable().optional() })
+  z.object({ items: Role.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -1209,10 +1167,7 @@ export const RouterRouteCreateParams = z.preprocess(
  */
 export const RouterRouteResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: RouterRoute.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: RouterRoute.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -1221,9 +1176,9 @@ export const RouterRouteResultsPage = z.preprocess(
 export const RouterRouteUpdateParams = z.preprocess(
   processResponseBody,
   z.object({
-    description: z.string().nullable().optional(),
+    description: z.string().optional(),
     destination: RouteDestination,
-    name: Name.nullable().optional(),
+    name: Name.optional(),
     target: RouteTarget,
   })
 );
@@ -1265,7 +1220,7 @@ export const Saga = z.preprocess(
  */
 export const SagaResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Saga.array(), nextPage: z.string().nullable().optional() })
+  z.object({ items: Saga.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -1279,7 +1234,7 @@ export const SamlIdentityProvider = z.preprocess(
     id: z.string().uuid(),
     idpEntityId: z.string(),
     name: Name,
-    publicCert: z.string().nullable().optional(),
+    publicCert: z.string().optional(),
     sloUrl: z.string(),
     spClientId: z.string(),
     technicalContactEmail: z.string(),
@@ -1296,11 +1251,11 @@ export const SamlIdentityProviderCreate = z.preprocess(
   z.object({
     acsUrl: z.string(),
     description: z.string(),
-    groupAttributeName: z.string().nullable().optional(),
+    groupAttributeName: z.string().optional(),
     idpEntityId: z.string(),
     idpMetadataSource: IdpMetadataSource,
     name: Name,
-    signingKeypair: DerEncodedKeyPair.nullable().optional(),
+    signingKeypair: DerEncodedKeyPair.optional(),
     sloUrl: z.string(),
     spClientId: z.string(),
     technicalContactEmail: z.string(),
@@ -1337,7 +1292,7 @@ export const Silo = z.preprocess(
 export const SiloCreate = z.preprocess(
   processResponseBody,
   z.object({
-    adminGroupName: z.string().nullable().optional(),
+    adminGroupName: z.string().optional(),
     description: z.string(),
     discoverable: z.boolean(),
     identityMode: SiloIdentityMode,
@@ -1350,7 +1305,7 @@ export const SiloCreate = z.preprocess(
  */
 export const SiloResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Silo.array(), nextPage: z.string().nullable().optional() })
+  z.object({ items: Silo.array(), nextPage: z.string().optional() })
 );
 
 export const SiloRole = z.preprocess(
@@ -1400,7 +1355,7 @@ export const Sled = z.preprocess(
  */
 export const SledResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Sled.array(), nextPage: z.string().nullable().optional() })
+  z.object({ items: Sled.array(), nextPage: z.string().optional() })
 );
 
 export const SnapshotState = z.preprocess(
@@ -1439,10 +1394,7 @@ export const SnapshotCreate = z.preprocess(
  */
 export const SnapshotResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Snapshot.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Snapshot.array(), nextPage: z.string().optional() })
 );
 
 export const SpoofLoginBody = z.preprocess(
@@ -1479,10 +1431,7 @@ export const SshKeyCreate = z.preprocess(
  */
 export const SshKeyResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: SshKey.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: SshKey.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -1519,10 +1468,7 @@ export const TimeseriesSchema = z.preprocess(
  */
 export const TimeseriesSchemaResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: TimeseriesSchema.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: TimeseriesSchema.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -1552,10 +1498,7 @@ export const UserBuiltin = z.preprocess(
  */
 export const UserBuiltinResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: UserBuiltin.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: UserBuiltin.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -1563,7 +1506,7 @@ export const UserBuiltinResultsPage = z.preprocess(
  */
 export const UserResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: User.array(), nextPage: z.string().nullable().optional() })
+  z.object({ items: User.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -1592,7 +1535,7 @@ export const VpcCreate = z.preprocess(
   z.object({
     description: z.string(),
     dnsName: Name,
-    ipv6Prefix: Ipv6Net.nullable().optional(),
+    ipv6Prefix: Ipv6Net.optional(),
     name: Name,
   })
 );
@@ -1635,9 +1578,9 @@ export const VpcFirewallRuleProtocol = z.preprocess(
 export const VpcFirewallRuleFilter = z.preprocess(
   processResponseBody,
   z.object({
-    hosts: VpcFirewallRuleHostFilter.array().nullable().optional(),
-    ports: L4PortRange.array().nullable().optional(),
-    protocols: VpcFirewallRuleProtocol.array().nullable().optional(),
+    hosts: VpcFirewallRuleHostFilter.array().optional(),
+    ports: L4PortRange.array().optional(),
+    protocols: VpcFirewallRuleProtocol.array().optional(),
   })
 );
 
@@ -1719,7 +1662,7 @@ export const VpcFirewallRules = z.preprocess(
  */
 export const VpcResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Vpc.array(), nextPage: z.string().nullable().optional() })
+  z.object({ items: Vpc.array(), nextPage: z.string().optional() })
 );
 
 export const VpcRouterKind = z.preprocess(
@@ -1756,10 +1699,7 @@ export const VpcRouterCreate = z.preprocess(
  */
 export const VpcRouterResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: VpcRouter.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: VpcRouter.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -1767,10 +1707,7 @@ export const VpcRouterResultsPage = z.preprocess(
  */
 export const VpcRouterUpdate = z.preprocess(
   processResponseBody,
-  z.object({
-    description: z.string().nullable().optional(),
-    name: Name.nullable().optional(),
-  })
+  z.object({ description: z.string().optional(), name: Name.optional() })
 );
 
 /**
@@ -1798,7 +1735,7 @@ export const VpcSubnetCreate = z.preprocess(
   z.object({
     description: z.string(),
     ipv4Block: Ipv4Net,
-    ipv6Block: Ipv6Net.nullable().optional(),
+    ipv6Block: Ipv6Net.optional(),
     name: Name,
   })
 );
@@ -1808,10 +1745,7 @@ export const VpcSubnetCreate = z.preprocess(
  */
 export const VpcSubnetResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: VpcSubnet.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: VpcSubnet.array(), nextPage: z.string().optional() })
 );
 
 /**
@@ -1819,10 +1753,7 @@ export const VpcSubnetResultsPage = z.preprocess(
  */
 export const VpcSubnetUpdate = z.preprocess(
   processResponseBody,
-  z.object({
-    description: z.string().nullable().optional(),
-    name: Name.nullable().optional(),
-  })
+  z.object({ description: z.string().optional(), name: Name.optional() })
 );
 
 /**
@@ -1831,9 +1762,9 @@ export const VpcSubnetUpdate = z.preprocess(
 export const VpcUpdate = z.preprocess(
   processResponseBody,
   z.object({
-    description: z.string().nullable().optional(),
-    dnsName: Name.nullable().optional(),
-    name: Name.nullable().optional(),
+    description: z.string().optional(),
+    dnsName: Name.optional(),
+    name: Name.optional(),
   })
 );
 
@@ -1985,8 +1916,8 @@ export const LogoutParams = z.preprocess(processResponseBody, z.object({}));
 export const OrganizationListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameOrIdSortMode.optional(),
   })
 );
@@ -2034,8 +1965,8 @@ export const OrganizationPolicyUpdateParams = z.preprocess(
 export const ProjectListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameOrIdSortMode.optional(),
     orgName: Name,
   })
@@ -2075,8 +2006,8 @@ export const ProjectDeleteParams = z.preprocess(
 export const DiskListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
     orgName: Name,
     projectName: Name,
@@ -2117,8 +2048,8 @@ export const DiskMetricsListParams = z.preprocess(
     orgName: Name,
     projectName: Name,
     endTime: DateType.optional(),
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     startTime: DateType.optional(),
   })
 );
@@ -2126,8 +2057,8 @@ export const DiskMetricsListParams = z.preprocess(
 export const ImageListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
     orgName: Name,
     projectName: Name,
@@ -2163,8 +2094,8 @@ export const ImageDeleteParams = z.preprocess(
 export const InstanceListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
     orgName: Name,
     projectName: Name,
@@ -2200,8 +2131,8 @@ export const InstanceDeleteParams = z.preprocess(
 export const InstanceDiskListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
     instanceName: Name,
     orgName: Name,
@@ -2248,8 +2179,8 @@ export const InstanceMigrateParams = z.preprocess(
 export const InstanceNetworkInterfaceListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
     instanceName: Name,
     orgName: Name,
@@ -2311,9 +2242,9 @@ export const InstanceSerialConsoleParams = z.preprocess(
     instanceName: Name,
     orgName: Name,
     projectName: Name,
-    fromStart: z.number().min(0).nullable().optional(),
-    maxBytes: z.number().min(0).nullable().optional(),
-    mostRecent: z.number().min(0).nullable().optional(),
+    fromStart: z.number().min(0).optional(),
+    maxBytes: z.number().min(0).optional(),
+    mostRecent: z.number().min(0).optional(),
   })
 );
 
@@ -2354,8 +2285,8 @@ export const ProjectPolicyUpdateParams = z.preprocess(
 export const SnapshotListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
     orgName: Name,
     projectName: Name,
@@ -2391,8 +2322,8 @@ export const SnapshotDeleteParams = z.preprocess(
 export const VpcListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
     orgName: Name,
     projectName: Name,
@@ -2455,8 +2386,8 @@ export const VpcFirewallRulesUpdateParams = z.preprocess(
 export const VpcRouterListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
     orgName: Name,
     projectName: Name,
@@ -2506,8 +2437,8 @@ export const VpcRouterDeleteParams = z.preprocess(
 export const VpcRouterRouteListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
     orgName: Name,
     projectName: Name,
@@ -2562,8 +2493,8 @@ export const VpcRouterRouteDeleteParams = z.preprocess(
 export const VpcSubnetListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
     orgName: Name,
     projectName: Name,
@@ -2613,8 +2544,8 @@ export const VpcSubnetDeleteParams = z.preprocess(
 export const VpcSubnetListNetworkInterfacesParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
     orgName: Name,
     projectName: Name,
@@ -2633,8 +2564,8 @@ export const PolicyUpdateParams = z.preprocess(
 export const RoleListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
   })
 );
 
@@ -2650,8 +2581,8 @@ export const SessionMeParams = z.preprocess(processResponseBody, z.object({}));
 export const SessionSshkeyListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
   })
 );
@@ -2699,8 +2630,8 @@ export const SiloViewByIdParams = z.preprocess(
 export const RackListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: IdSortMode.optional(),
   })
 );
@@ -2715,8 +2646,8 @@ export const RackViewParams = z.preprocess(
 export const SledListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: IdSortMode.optional(),
   })
 );
@@ -2731,8 +2662,8 @@ export const SledViewParams = z.preprocess(
 export const SystemImageListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
   })
 );
@@ -2759,8 +2690,8 @@ export const SystemImageDeleteParams = z.preprocess(
 export const IpPoolListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameOrIdSortMode.optional(),
   })
 );
@@ -2795,8 +2726,8 @@ export const IpPoolRangeListParams = z.preprocess(
   processResponseBody,
   z.object({
     poolName: Name,
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
   })
 );
 
@@ -2825,8 +2756,8 @@ export const IpPoolServiceRangeListParams = z.preprocess(
   processResponseBody,
   z.object({
     rackId: z.string().uuid(),
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
   })
 );
 
@@ -2857,8 +2788,8 @@ export const SystemPolicyUpdateParams = z.preprocess(
 export const SagaListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: IdSortMode.optional(),
   })
 );
@@ -2873,8 +2804,8 @@ export const SagaViewParams = z.preprocess(
 export const SiloListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameOrIdSortMode.optional(),
   })
 );
@@ -2899,8 +2830,8 @@ export const SiloIdentityProviderListParams = z.preprocess(
   processResponseBody,
   z.object({
     siloName: Name,
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
   })
 );
@@ -2942,8 +2873,8 @@ export const UpdatesRefreshParams = z.preprocess(
 export const SystemUserListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: NameSortMode.optional(),
   })
 );
@@ -2958,16 +2889,16 @@ export const SystemUserViewParams = z.preprocess(
 export const TimeseriesSchemaGetParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
   })
 );
 
 export const UserListParams = z.preprocess(
   processResponseBody,
   z.object({
-    limit: z.number().min(1).max(4294967295).nullable().optional(),
-    pageToken: z.string().nullable().optional(),
+    limit: z.number().min(1).max(4294967295).optional(),
+    pageToken: z.string().optional(),
     sortBy: IdSortMode.optional(),
   })
 );

--- a/lib/schema/types.ts
+++ b/lib/schema/types.ts
@@ -18,11 +18,8 @@ export const schemaToTypes = makeSchemaGenerator({
   boolean(_, { w0 }) {
     w0(`boolean`);
   },
-  string(schema, { w0 }) {
+  string(_, { w0 }) {
     w0(`string`);
-    if ("nullable" in schema) {
-      w0(` | null`);
-    }
   },
   date(_, { w0 }) {
     w0(`Date`);
@@ -36,9 +33,6 @@ export const schemaToTypes = makeSchemaGenerator({
   array(schema, io) {
     schemaToTypes(schema.items, io);
     io.w0(`[]`);
-    if ("nullable" in schema) {
-      io.w0(` | null`);
-    }
   },
   object(schema, io) {
     const { w0, w } = io;
@@ -74,9 +68,6 @@ export const schemaToTypes = makeSchemaGenerator({
       for (const s of schema.allOf!) {
         io.w(`& ${JSON.stringify(s)}`);
       }
-    }
-    if ("nullable" in schema) {
-      io.w0(` | null`);
     }
   },
   empty({ w0 }) {

--- a/lib/schema/zod.ts
+++ b/lib/schema/zod.ts
@@ -45,9 +45,6 @@ export const schemaToZod = makeSchemaGenerator({
     if ("pattern" in schema) {
       w0(`.regex(${new RegExp(schema.pattern!).toString()})`);
     }
-    if ("nullable" in schema) {
-      w0(".nullable()");
-    }
   },
 
   date(_, { w0 }) {
@@ -66,9 +63,6 @@ export const schemaToZod = makeSchemaGenerator({
     w0(".array()");
     if ("default" in schema) {
       w0(`.default(${JSON.stringify(schema.default)})`);
-    }
-    if ("nullable" in schema) {
-      w0(".nullable()");
     }
   },
 
@@ -143,9 +137,6 @@ export const schemaToZod = makeSchemaGenerator({
     if ("default" in schema) {
       w0(`.default(${JSON.stringify(schema.default)})`);
     }
-    if ("nullable" in schema) {
-      w0(`.nullable()`);
-    }
   },
 
   empty({ w0 }) {
@@ -185,9 +176,5 @@ function schemaToZodInt(schema: OpenAPIV3.SchemaObject, { w0 }: IO) {
   } else if (size && parseInt(size) < 64) {
     // It's signed so remove the most significant bit
     w0(`.max(${Math.pow(2, parseInt(size) - 1) - 1})`);
-  }
-
-  if ("nullable" in schema) {
-    w0(".nullable()");
   }
 }


### PR DESCRIPTION
As I was going through and adding validators to MSW I kept running into type oddities where `null` was a valid input in places where it seemed like it really shouldn't be. Pagination query parameters for instance. As I investigated further, every instance of `nullability` in the spec corresponded to an optional property of an object (the object itself defines the optionality of its children). Given that, I think the `nullable` entries are incorrect or at least duplicative. I've removed them in this PR. 