### PR TITLE
404 instead of 400 if any path params are invalid

### DIFF
--- a/client/msw-handlers.ts
+++ b/client/msw-handlers.ts
@@ -636,10 +636,16 @@ function validateParams<S extends ZodSchema>(schema: S, req: RestRequest) {
     path: req.params,
     query: Object.fromEntries(params),
   });
+
   if (result.success) {
     return { params: result.data };
   }
-  return { paramsErr: json(result.error.issues, { status: 400 }) };
+
+  // if any of the errors come from path params, just 404 — the resource cannot
+  // exist if there's no valid name
+  const { issues } = result.error;
+  const status = issues.some((e) => e.path[0] === "path") ? 404 : 400;
+  return { paramsErr: json(issues, { status }) };
 }
 
 const handler =

--- a/lib/client/msw-handlers.ts
+++ b/lib/client/msw-handlers.ts
@@ -139,10 +139,16 @@ export function generateMSWHandlers(spec: OpenAPIV3.Document) {
         path: req.params,
         query: Object.fromEntries(params),
       })
+
       if (result.success) {
         return { params: result.data }
       }
-      return { paramsErr: json(result.error.issues, { status: 400 }) }
+
+      // if any of the errors come from path params, just 404 — the resource cannot
+      // exist if there's no valid name
+      const { issues } = result.error
+      const status = issues.some(e => e.path[0] === 'path') ? 404 : 400
+      return { paramsErr: json(issues, { status }) }
     }
 
     const handler = (handler: MSWHandlers[keyof MSWHandlers], paramSchema: ZodSchema | null, bodySchema: ZodSchema | null) => 


### PR DESCRIPTION
I noticed while testing a 404 page change in the console that `/orgs/maze-w` 404s as expected, but `/orgs/maze-` 400s. It turns out we were failing validation. This change makes it so that if any of the parse errors come from the path instead of the query params, we 404 instead of 400.