### PR TITLE
Handle path variables so we don't break on reserved words

### DIFF
--- a/client/Api.ts
+++ b/client/Api.ts
@@ -2624,9 +2624,8 @@ export class Api extends HttpClient {
       { path }: { path: DiskViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<Disk>({
-        path: `/by-id/disks/${id}`,
+        path: `/by-id/disks/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -2638,9 +2637,8 @@ export class Api extends HttpClient {
       { path }: { path: ImageViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<Image>({
-        path: `/by-id/images/${id}`,
+        path: `/by-id/images/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -2652,9 +2650,8 @@ export class Api extends HttpClient {
       { path }: { path: InstanceViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<Instance>({
-        path: `/by-id/instances/${id}`,
+        path: `/by-id/instances/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -2666,9 +2663,8 @@ export class Api extends HttpClient {
       { path }: { path: InstanceNetworkInterfaceViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<NetworkInterface>({
-        path: `/by-id/network-interfaces/${id}`,
+        path: `/by-id/network-interfaces/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -2680,9 +2676,8 @@ export class Api extends HttpClient {
       { path }: { path: OrganizationViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<Organization>({
-        path: `/by-id/organizations/${id}`,
+        path: `/by-id/organizations/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -2694,9 +2689,8 @@ export class Api extends HttpClient {
       { path }: { path: ProjectViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<Project>({
-        path: `/by-id/projects/${id}`,
+        path: `/by-id/projects/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -2708,9 +2702,8 @@ export class Api extends HttpClient {
       { path }: { path: SnapshotViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<Snapshot>({
-        path: `/by-id/snapshots/${id}`,
+        path: `/by-id/snapshots/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -2722,9 +2715,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcRouterRouteViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<RouterRoute>({
-        path: `/by-id/vpc-router-routes/${id}`,
+        path: `/by-id/vpc-router-routes/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -2736,9 +2728,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcRouterViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<VpcRouter>({
-        path: `/by-id/vpc-routers/${id}`,
+        path: `/by-id/vpc-routers/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -2750,9 +2741,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcSubnetViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<VpcSubnet>({
-        path: `/by-id/vpc-subnets/${id}`,
+        path: `/by-id/vpc-subnets/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -2764,9 +2754,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<Vpc>({
-        path: `/by-id/vpcs/${id}`,
+        path: `/by-id/vpcs/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -2840,9 +2829,8 @@ export class Api extends HttpClient {
       }: { path: LoginLocalPathParams; body: UsernamePasswordCredentials },
       params: RequestParams = {}
     ) => {
-      const { siloName } = path;
       return this.request<void>({
-        path: `/login/${siloName}/local`,
+        path: `/login/${path.siloName}/local`,
         method: "POST",
         body,
         ...params,
@@ -2855,9 +2843,8 @@ export class Api extends HttpClient {
       { path }: { path: LoginSamlBeginPathParams },
       params: RequestParams = {}
     ) => {
-      const { providerName, siloName } = path;
       return this.request<void>({
-        path: `/login/${siloName}/saml/${providerName}`,
+        path: `/login/${path.siloName}/saml/${path.providerName}`,
         method: "GET",
         ...params,
       });
@@ -2869,9 +2856,8 @@ export class Api extends HttpClient {
       { path }: { path: LoginSamlPathParams },
       params: RequestParams = {}
     ) => {
-      const { providerName, siloName } = path;
       return this.request<void>({
-        path: `/login/${siloName}/saml/${providerName}`,
+        path: `/login/${path.siloName}/saml/${path.providerName}`,
         method: "POST",
         ...params,
       });
@@ -2918,9 +2904,8 @@ export class Api extends HttpClient {
       { path }: { path: OrganizationViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName } = path;
       return this.request<Organization>({
-        path: `/organizations/${orgName}`,
+        path: `/organizations/${path.orgName}`,
         method: "GET",
         ...params,
       });
@@ -2935,9 +2920,8 @@ export class Api extends HttpClient {
       }: { path: OrganizationUpdatePathParams; body: OrganizationUpdate },
       params: RequestParams = {}
     ) => {
-      const { orgName } = path;
       return this.request<Organization>({
-        path: `/organizations/${orgName}`,
+        path: `/organizations/${path.orgName}`,
         method: "PUT",
         body,
         ...params,
@@ -2950,9 +2934,8 @@ export class Api extends HttpClient {
       { path }: { path: OrganizationDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}`,
+        path: `/organizations/${path.orgName}`,
         method: "DELETE",
         ...params,
       });
@@ -2964,9 +2947,8 @@ export class Api extends HttpClient {
       { path }: { path: OrganizationPolicyViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName } = path;
       return this.request<OrganizationRolePolicy>({
-        path: `/organizations/${orgName}/policy`,
+        path: `/organizations/${path.orgName}/policy`,
         method: "GET",
         ...params,
       });
@@ -2984,9 +2966,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { orgName } = path;
       return this.request<OrganizationRolePolicy>({
-        path: `/organizations/${orgName}/policy`,
+        path: `/organizations/${path.orgName}/policy`,
         method: "PUT",
         body,
         ...params,
@@ -3002,9 +2983,8 @@ export class Api extends HttpClient {
       }: { path: ProjectListPathParams; query?: ProjectListQueryParams },
       params: RequestParams = {}
     ) => {
-      const { orgName } = path;
       return this.request<ProjectResultsPage>({
-        path: `/organizations/${orgName}/projects`,
+        path: `/organizations/${path.orgName}/projects`,
         method: "GET",
         query,
         ...params,
@@ -3017,9 +2997,8 @@ export class Api extends HttpClient {
       { path, body }: { path: ProjectCreatePathParams; body: ProjectCreate },
       params: RequestParams = {}
     ) => {
-      const { orgName } = path;
       return this.request<Project>({
-        path: `/organizations/${orgName}/projects`,
+        path: `/organizations/${path.orgName}/projects`,
         method: "POST",
         body,
         ...params,
@@ -3032,9 +3011,8 @@ export class Api extends HttpClient {
       { path }: { path: ProjectViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<Project>({
-        path: `/organizations/${orgName}/projects/${projectName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}`,
         method: "GET",
         ...params,
       });
@@ -3046,9 +3024,8 @@ export class Api extends HttpClient {
       { path, body }: { path: ProjectUpdatePathParams; body: ProjectUpdate },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<Project>({
-        path: `/organizations/${orgName}/projects/${projectName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}`,
         method: "PUT",
         body,
         ...params,
@@ -3061,9 +3038,8 @@ export class Api extends HttpClient {
       { path }: { path: ProjectDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}/projects/${projectName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}`,
         method: "DELETE",
         ...params,
       });
@@ -3078,9 +3054,8 @@ export class Api extends HttpClient {
       }: { path: DiskListPathParams; query?: DiskListQueryParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<DiskResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/disks`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/disks`,
         method: "GET",
         query,
         ...params,
@@ -3093,9 +3068,8 @@ export class Api extends HttpClient {
       { path, body }: { path: DiskCreatePathParams; body: DiskCreate },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<Disk>({
-        path: `/organizations/${orgName}/projects/${projectName}/disks`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/disks`,
         method: "POST",
         body,
         ...params,
@@ -3108,9 +3082,8 @@ export class Api extends HttpClient {
       { path }: { path: DiskViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { diskName, orgName, projectName } = path;
       return this.request<Disk>({
-        path: `/organizations/${orgName}/projects/${projectName}/disks/${diskName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/disks/${path.diskName}`,
         method: "GET",
         ...params,
       });
@@ -3122,9 +3095,8 @@ export class Api extends HttpClient {
       { path }: { path: DiskDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { diskName, orgName, projectName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}/projects/${projectName}/disks/${diskName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/disks/${path.diskName}`,
         method: "DELETE",
         ...params,
       });
@@ -3142,9 +3114,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { diskName, metricName, orgName, projectName } = path;
       return this.request<MeasurementResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/disks/${diskName}/metrics/${metricName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/disks/${path.diskName}/metrics/${path.metricName}`,
         method: "GET",
         query,
         ...params,
@@ -3160,9 +3131,8 @@ export class Api extends HttpClient {
       }: { path: ImageListPathParams; query?: ImageListQueryParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<ImageResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/images`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/images`,
         method: "GET",
         query,
         ...params,
@@ -3175,9 +3145,8 @@ export class Api extends HttpClient {
       { path, body }: { path: ImageCreatePathParams; body: ImageCreate },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<Image>({
-        path: `/organizations/${orgName}/projects/${projectName}/images`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/images`,
         method: "POST",
         body,
         ...params,
@@ -3190,9 +3159,8 @@ export class Api extends HttpClient {
       { path }: { path: ImageViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { imageName, orgName, projectName } = path;
       return this.request<Image>({
-        path: `/organizations/${orgName}/projects/${projectName}/images/${imageName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/images/${path.imageName}`,
         method: "GET",
         ...params,
       });
@@ -3204,9 +3172,8 @@ export class Api extends HttpClient {
       { path }: { path: ImageDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { imageName, orgName, projectName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}/projects/${projectName}/images/${imageName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/images/${path.imageName}`,
         method: "DELETE",
         ...params,
       });
@@ -3221,9 +3188,8 @@ export class Api extends HttpClient {
       }: { path: InstanceListPathParams; query?: InstanceListQueryParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<InstanceResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances`,
         method: "GET",
         query,
         ...params,
@@ -3236,9 +3202,8 @@ export class Api extends HttpClient {
       { path, body }: { path: InstanceCreatePathParams; body: InstanceCreate },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<Instance>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances`,
         method: "POST",
         body,
         ...params,
@@ -3251,9 +3216,8 @@ export class Api extends HttpClient {
       { path }: { path: InstanceViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<Instance>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}`,
         method: "GET",
         ...params,
       });
@@ -3265,9 +3229,8 @@ export class Api extends HttpClient {
       { path }: { path: InstanceDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}`,
         method: "DELETE",
         ...params,
       });
@@ -3285,9 +3248,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<DiskResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/disks`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/disks`,
         method: "GET",
         query,
         ...params,
@@ -3303,9 +3265,8 @@ export class Api extends HttpClient {
       }: { path: InstanceDiskAttachPathParams; body: DiskIdentifier },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<Disk>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/disks/attach`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/disks/attach`,
         method: "POST",
         body,
         ...params,
@@ -3321,9 +3282,8 @@ export class Api extends HttpClient {
       }: { path: InstanceDiskDetachPathParams; body: DiskIdentifier },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<Disk>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/disks/detach`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/disks/detach`,
         method: "POST",
         body,
         ...params,
@@ -3336,9 +3296,8 @@ export class Api extends HttpClient {
       { path }: { path: InstanceExternalIpListPathParams },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<ExternalIpResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/external-ips`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/external-ips`,
         method: "GET",
         ...params,
       });
@@ -3353,9 +3312,8 @@ export class Api extends HttpClient {
       }: { path: InstanceMigratePathParams; body: InstanceMigrate },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<Instance>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/migrate`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/migrate`,
         method: "POST",
         body,
         ...params,
@@ -3374,9 +3332,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<NetworkInterfaceResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/network-interfaces`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/network-interfaces`,
         method: "GET",
         query,
         ...params,
@@ -3395,9 +3352,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<NetworkInterface>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/network-interfaces`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/network-interfaces`,
         method: "POST",
         body,
         ...params,
@@ -3410,9 +3366,8 @@ export class Api extends HttpClient {
       { path }: { path: InstanceNetworkInterfaceViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { instanceName, interfaceName, orgName, projectName } = path;
       return this.request<NetworkInterface>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/network-interfaces/${interfaceName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/network-interfaces/${path.interfaceName}`,
         method: "GET",
         ...params,
       });
@@ -3430,9 +3385,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { instanceName, interfaceName, orgName, projectName } = path;
       return this.request<NetworkInterface>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/network-interfaces/${interfaceName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/network-interfaces/${path.interfaceName}`,
         method: "PUT",
         body,
         ...params,
@@ -3445,9 +3399,8 @@ export class Api extends HttpClient {
       { path }: { path: InstanceNetworkInterfaceDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { instanceName, interfaceName, orgName, projectName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/network-interfaces/${interfaceName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/network-interfaces/${path.interfaceName}`,
         method: "DELETE",
         ...params,
       });
@@ -3459,9 +3412,8 @@ export class Api extends HttpClient {
       { path }: { path: InstanceRebootPathParams },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<Instance>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/reboot`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/reboot`,
         method: "POST",
         ...params,
       });
@@ -3479,9 +3431,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<InstanceSerialConsoleData>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/serial-console`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/serial-console`,
         method: "GET",
         query,
         ...params,
@@ -3494,9 +3445,8 @@ export class Api extends HttpClient {
       { path }: { path: InstanceSerialConsoleStreamPathParams },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/serial-console/stream`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/serial-console/stream`,
         method: "GET",
         ...params,
       });
@@ -3508,9 +3458,8 @@ export class Api extends HttpClient {
       { path }: { path: InstanceStartPathParams },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<Instance>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/start`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/start`,
         method: "POST",
         ...params,
       });
@@ -3522,9 +3471,8 @@ export class Api extends HttpClient {
       { path }: { path: InstanceStopPathParams },
       params: RequestParams = {}
     ) => {
-      const { instanceName, orgName, projectName } = path;
       return this.request<Instance>({
-        path: `/organizations/${orgName}/projects/${projectName}/instances/${instanceName}/stop`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/instances/${path.instanceName}/stop`,
         method: "POST",
         ...params,
       });
@@ -3536,9 +3484,8 @@ export class Api extends HttpClient {
       { path }: { path: ProjectPolicyViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<ProjectRolePolicy>({
-        path: `/organizations/${orgName}/projects/${projectName}/policy`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/policy`,
         method: "GET",
         ...params,
       });
@@ -3553,9 +3500,8 @@ export class Api extends HttpClient {
       }: { path: ProjectPolicyUpdatePathParams; body: ProjectRolePolicy },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<ProjectRolePolicy>({
-        path: `/organizations/${orgName}/projects/${projectName}/policy`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/policy`,
         method: "PUT",
         body,
         ...params,
@@ -3571,9 +3517,8 @@ export class Api extends HttpClient {
       }: { path: SnapshotListPathParams; query?: SnapshotListQueryParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<SnapshotResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/snapshots`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/snapshots`,
         method: "GET",
         query,
         ...params,
@@ -3586,9 +3531,8 @@ export class Api extends HttpClient {
       { path, body }: { path: SnapshotCreatePathParams; body: SnapshotCreate },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<Snapshot>({
-        path: `/organizations/${orgName}/projects/${projectName}/snapshots`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/snapshots`,
         method: "POST",
         body,
         ...params,
@@ -3601,9 +3545,8 @@ export class Api extends HttpClient {
       { path }: { path: SnapshotViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, snapshotName } = path;
       return this.request<Snapshot>({
-        path: `/organizations/${orgName}/projects/${projectName}/snapshots/${snapshotName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/snapshots/${path.snapshotName}`,
         method: "GET",
         ...params,
       });
@@ -3615,9 +3558,8 @@ export class Api extends HttpClient {
       { path }: { path: SnapshotDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, snapshotName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}/projects/${projectName}/snapshots/${snapshotName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/snapshots/${path.snapshotName}`,
         method: "DELETE",
         ...params,
       });
@@ -3632,9 +3574,8 @@ export class Api extends HttpClient {
       }: { path: VpcListPathParams; query?: VpcListQueryParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<VpcResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs`,
         method: "GET",
         query,
         ...params,
@@ -3647,9 +3588,8 @@ export class Api extends HttpClient {
       { path, body }: { path: VpcCreatePathParams; body: VpcCreate },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName } = path;
       return this.request<Vpc>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs`,
         method: "POST",
         body,
         ...params,
@@ -3662,9 +3602,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, vpcName } = path;
       return this.request<Vpc>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}`,
         method: "GET",
         ...params,
       });
@@ -3676,9 +3615,8 @@ export class Api extends HttpClient {
       { path, body }: { path: VpcUpdatePathParams; body: VpcUpdate },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, vpcName } = path;
       return this.request<Vpc>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}`,
         method: "PUT",
         body,
         ...params,
@@ -3691,9 +3629,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, vpcName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}`,
         method: "DELETE",
         ...params,
       });
@@ -3705,9 +3642,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcFirewallRulesViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, vpcName } = path;
       return this.request<VpcFirewallRules>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/firewall/rules`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/firewall/rules`,
         method: "GET",
         ...params,
       });
@@ -3725,9 +3661,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, vpcName } = path;
       return this.request<VpcFirewallRules>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/firewall/rules`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/firewall/rules`,
         method: "PUT",
         body,
         ...params,
@@ -3743,9 +3678,8 @@ export class Api extends HttpClient {
       }: { path: VpcRouterListPathParams; query?: VpcRouterListQueryParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, vpcName } = path;
       return this.request<VpcRouterResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/routers`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/routers`,
         method: "GET",
         query,
         ...params,
@@ -3761,9 +3695,8 @@ export class Api extends HttpClient {
       }: { path: VpcRouterCreatePathParams; body: VpcRouterCreate },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, vpcName } = path;
       return this.request<VpcRouter>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/routers`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/routers`,
         method: "POST",
         body,
         ...params,
@@ -3776,9 +3709,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcRouterViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, routerName, vpcName } = path;
       return this.request<VpcRouter>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/routers/${routerName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/routers/${path.routerName}`,
         method: "GET",
         ...params,
       });
@@ -3793,9 +3725,8 @@ export class Api extends HttpClient {
       }: { path: VpcRouterUpdatePathParams; body: VpcRouterUpdate },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, routerName, vpcName } = path;
       return this.request<VpcRouter>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/routers/${routerName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/routers/${path.routerName}`,
         method: "PUT",
         body,
         ...params,
@@ -3808,9 +3739,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcRouterDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, routerName, vpcName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/routers/${routerName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/routers/${path.routerName}`,
         method: "DELETE",
         ...params,
       });
@@ -3828,9 +3758,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, routerName, vpcName } = path;
       return this.request<RouterRouteResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/routers/${routerName}/routes`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/routers/${path.routerName}/routes`,
         method: "GET",
         query,
         ...params,
@@ -3849,9 +3778,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, routerName, vpcName } = path;
       return this.request<RouterRoute>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/routers/${routerName}/routes`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/routers/${path.routerName}/routes`,
         method: "POST",
         body,
         ...params,
@@ -3864,9 +3792,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcRouterRouteViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, routeName, routerName, vpcName } = path;
       return this.request<RouterRoute>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/routers/${routerName}/routes/${routeName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/routers/${path.routerName}/routes/${path.routeName}`,
         method: "GET",
         ...params,
       });
@@ -3884,9 +3811,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, routeName, routerName, vpcName } = path;
       return this.request<RouterRoute>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/routers/${routerName}/routes/${routeName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/routers/${path.routerName}/routes/${path.routeName}`,
         method: "PUT",
         body,
         ...params,
@@ -3899,9 +3825,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcRouterRouteDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, routeName, routerName, vpcName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/routers/${routerName}/routes/${routeName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/routers/${path.routerName}/routes/${path.routeName}`,
         method: "DELETE",
         ...params,
       });
@@ -3916,9 +3841,8 @@ export class Api extends HttpClient {
       }: { path: VpcSubnetListPathParams; query?: VpcSubnetListQueryParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, vpcName } = path;
       return this.request<VpcSubnetResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/subnets`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/subnets`,
         method: "GET",
         query,
         ...params,
@@ -3934,9 +3858,8 @@ export class Api extends HttpClient {
       }: { path: VpcSubnetCreatePathParams; body: VpcSubnetCreate },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, vpcName } = path;
       return this.request<VpcSubnet>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/subnets`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/subnets`,
         method: "POST",
         body,
         ...params,
@@ -3949,9 +3872,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcSubnetViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, subnetName, vpcName } = path;
       return this.request<VpcSubnet>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/subnets/${subnetName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/subnets/${path.subnetName}`,
         method: "GET",
         ...params,
       });
@@ -3966,9 +3888,8 @@ export class Api extends HttpClient {
       }: { path: VpcSubnetUpdatePathParams; body: VpcSubnetUpdate },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, subnetName, vpcName } = path;
       return this.request<VpcSubnet>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/subnets/${subnetName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/subnets/${path.subnetName}`,
         method: "PUT",
         body,
         ...params,
@@ -3981,9 +3902,8 @@ export class Api extends HttpClient {
       { path }: { path: VpcSubnetDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, subnetName, vpcName } = path;
       return this.request<void>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/subnets/${subnetName}`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/subnets/${path.subnetName}`,
         method: "DELETE",
         ...params,
       });
@@ -4001,9 +3921,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { orgName, projectName, subnetName, vpcName } = path;
       return this.request<NetworkInterfaceResultsPage>({
-        path: `/organizations/${orgName}/projects/${projectName}/vpcs/${vpcName}/subnets/${subnetName}/network-interfaces`,
+        path: `/organizations/${path.orgName}/projects/${path.projectName}/vpcs/${path.vpcName}/subnets/${path.subnetName}/network-interfaces`,
         method: "GET",
         query,
         ...params,
@@ -4054,9 +3973,8 @@ export class Api extends HttpClient {
       { path }: { path: RoleViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { roleName } = path;
       return this.request<Role>({
-        path: `/roles/${roleName}`,
+        path: `/roles/${path.roleName}`,
         method: "GET",
         ...params,
       });
@@ -4120,9 +4038,8 @@ export class Api extends HttpClient {
       { path }: { path: SessionSshkeyViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { sshKeyName } = path;
       return this.request<SshKey>({
-        path: `/session/me/sshkeys/${sshKeyName}`,
+        path: `/session/me/sshkeys/${path.sshKeyName}`,
         method: "GET",
         ...params,
       });
@@ -4134,9 +4051,8 @@ export class Api extends HttpClient {
       { path }: { path: SessionSshkeyDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { sshKeyName } = path;
       return this.request<void>({
-        path: `/session/me/sshkeys/${sshKeyName}`,
+        path: `/session/me/sshkeys/${path.sshKeyName}`,
         method: "DELETE",
         ...params,
       });
@@ -4148,9 +4064,8 @@ export class Api extends HttpClient {
       { path }: { path: SystemImageViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<GlobalImage>({
-        path: `/system/by-id/images/${id}`,
+        path: `/system/by-id/images/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -4162,9 +4077,8 @@ export class Api extends HttpClient {
       { path }: { path: IpPoolViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<IpPool>({
-        path: `/system/by-id/ip-pools/${id}`,
+        path: `/system/by-id/ip-pools/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -4176,9 +4090,8 @@ export class Api extends HttpClient {
       { path }: { path: SiloViewByIdPathParams },
       params: RequestParams = {}
     ) => {
-      const { id } = path;
       return this.request<Silo>({
-        path: `/system/by-id/silos/${id}`,
+        path: `/system/by-id/silos/${path.id}`,
         method: "GET",
         ...params,
       });
@@ -4204,9 +4117,8 @@ export class Api extends HttpClient {
       { path }: { path: RackViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { rackId } = path;
       return this.request<Rack>({
-        path: `/system/hardware/racks/${rackId}`,
+        path: `/system/hardware/racks/${path.rackId}`,
         method: "GET",
         ...params,
       });
@@ -4232,9 +4144,8 @@ export class Api extends HttpClient {
       { path }: { path: SledViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { sledId } = path;
       return this.request<Sled>({
-        path: `/system/hardware/sleds/${sledId}`,
+        path: `/system/hardware/sleds/${path.sledId}`,
         method: "GET",
         ...params,
       });
@@ -4274,9 +4185,8 @@ export class Api extends HttpClient {
       { path }: { path: SystemImageViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { imageName } = path;
       return this.request<GlobalImage>({
-        path: `/system/images/${imageName}`,
+        path: `/system/images/${path.imageName}`,
         method: "GET",
         ...params,
       });
@@ -4288,9 +4198,8 @@ export class Api extends HttpClient {
       { path }: { path: SystemImageDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { imageName } = path;
       return this.request<void>({
-        path: `/system/images/${imageName}`,
+        path: `/system/images/${path.imageName}`,
         method: "DELETE",
         ...params,
       });
@@ -4330,9 +4239,8 @@ export class Api extends HttpClient {
       { path }: { path: IpPoolViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { poolName } = path;
       return this.request<IpPool>({
-        path: `/system/ip-pools/${poolName}`,
+        path: `/system/ip-pools/${path.poolName}`,
         method: "GET",
         ...params,
       });
@@ -4344,9 +4252,8 @@ export class Api extends HttpClient {
       { path, body }: { path: IpPoolUpdatePathParams; body: IpPoolUpdate },
       params: RequestParams = {}
     ) => {
-      const { poolName } = path;
       return this.request<IpPool>({
-        path: `/system/ip-pools/${poolName}`,
+        path: `/system/ip-pools/${path.poolName}`,
         method: "PUT",
         body,
         ...params,
@@ -4359,9 +4266,8 @@ export class Api extends HttpClient {
       { path }: { path: IpPoolDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { poolName } = path;
       return this.request<void>({
-        path: `/system/ip-pools/${poolName}`,
+        path: `/system/ip-pools/${path.poolName}`,
         method: "DELETE",
         ...params,
       });
@@ -4379,9 +4285,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { poolName } = path;
       return this.request<IpPoolRangeResultsPage>({
-        path: `/system/ip-pools/${poolName}/ranges`,
+        path: `/system/ip-pools/${path.poolName}/ranges`,
         method: "GET",
         query,
         ...params,
@@ -4394,9 +4299,8 @@ export class Api extends HttpClient {
       { path, body }: { path: IpPoolRangeAddPathParams; body: IpRange },
       params: RequestParams = {}
     ) => {
-      const { poolName } = path;
       return this.request<IpPoolRange>({
-        path: `/system/ip-pools/${poolName}/ranges/add`,
+        path: `/system/ip-pools/${path.poolName}/ranges/add`,
         method: "POST",
         body,
         ...params,
@@ -4409,9 +4313,8 @@ export class Api extends HttpClient {
       { path, body }: { path: IpPoolRangeRemovePathParams; body: IpRange },
       params: RequestParams = {}
     ) => {
-      const { poolName } = path;
       return this.request<void>({
-        path: `/system/ip-pools/${poolName}/ranges/remove`,
+        path: `/system/ip-pools/${path.poolName}/ranges/remove`,
         method: "POST",
         body,
         ...params,
@@ -4424,9 +4327,8 @@ export class Api extends HttpClient {
       { path }: { path: IpPoolServiceViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { rackId } = path;
       return this.request<IpPool>({
-        path: `/system/ip-pools-service/${rackId}`,
+        path: `/system/ip-pools-service/${path.rackId}`,
         method: "GET",
         ...params,
       });
@@ -4444,9 +4346,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { rackId } = path;
       return this.request<IpPoolRangeResultsPage>({
-        path: `/system/ip-pools-service/${rackId}/ranges`,
+        path: `/system/ip-pools-service/${path.rackId}/ranges`,
         method: "GET",
         query,
         ...params,
@@ -4459,9 +4360,8 @@ export class Api extends HttpClient {
       { path, body }: { path: IpPoolServiceRangeAddPathParams; body: IpRange },
       params: RequestParams = {}
     ) => {
-      const { rackId } = path;
       return this.request<IpPoolRange>({
-        path: `/system/ip-pools-service/${rackId}/ranges/add`,
+        path: `/system/ip-pools-service/${path.rackId}/ranges/add`,
         method: "POST",
         body,
         ...params,
@@ -4477,9 +4377,8 @@ export class Api extends HttpClient {
       }: { path: IpPoolServiceRangeRemovePathParams; body: IpRange },
       params: RequestParams = {}
     ) => {
-      const { rackId } = path;
       return this.request<void>({
-        path: `/system/ip-pools-service/${rackId}/ranges/remove`,
+        path: `/system/ip-pools-service/${path.rackId}/ranges/remove`,
         method: "POST",
         body,
         ...params,
@@ -4530,9 +4429,8 @@ export class Api extends HttpClient {
       { path }: { path: SagaViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { sagaId } = path;
       return this.request<Saga>({
-        path: `/system/sagas/${sagaId}`,
+        path: `/system/sagas/${path.sagaId}`,
         method: "GET",
         ...params,
       });
@@ -4572,9 +4470,8 @@ export class Api extends HttpClient {
       { path }: { path: SiloViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { siloName } = path;
       return this.request<Silo>({
-        path: `/system/silos/${siloName}`,
+        path: `/system/silos/${path.siloName}`,
         method: "GET",
         ...params,
       });
@@ -4586,9 +4483,8 @@ export class Api extends HttpClient {
       { path }: { path: SiloDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { siloName } = path;
       return this.request<void>({
-        path: `/system/silos/${siloName}`,
+        path: `/system/silos/${path.siloName}`,
         method: "DELETE",
         ...params,
       });
@@ -4606,9 +4502,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { siloName } = path;
       return this.request<IdentityProviderResultsPage>({
-        path: `/system/silos/${siloName}/identity-providers`,
+        path: `/system/silos/${path.siloName}/identity-providers`,
         method: "GET",
         query,
         ...params,
@@ -4621,9 +4516,8 @@ export class Api extends HttpClient {
       { path, body }: { path: LocalIdpUserCreatePathParams; body: UserCreate },
       params: RequestParams = {}
     ) => {
-      const { siloName } = path;
       return this.request<User>({
-        path: `/system/silos/${siloName}/identity-providers/local/users`,
+        path: `/system/silos/${path.siloName}/identity-providers/local/users`,
         method: "POST",
         body,
         ...params,
@@ -4633,9 +4527,8 @@ export class Api extends HttpClient {
       { path }: { path: LocalIdpUserDeletePathParams },
       params: RequestParams = {}
     ) => {
-      const { siloName, userId } = path;
       return this.request<void>({
-        path: `/system/silos/${siloName}/identity-providers/local/users/${userId}`,
+        path: `/system/silos/${path.siloName}/identity-providers/local/users/${path.userId}`,
         method: "DELETE",
         ...params,
       });
@@ -4650,9 +4543,8 @@ export class Api extends HttpClient {
       }: { path: LocalIdpUserSetPasswordPathParams; body: UserPassword },
       params: RequestParams = {}
     ) => {
-      const { siloName, userId } = path;
       return this.request<void>({
-        path: `/system/silos/${siloName}/identity-providers/local/users/${userId}/set-password`,
+        path: `/system/silos/${path.siloName}/identity-providers/local/users/${path.userId}/set-password`,
         method: "POST",
         body,
         ...params,
@@ -4671,9 +4563,8 @@ export class Api extends HttpClient {
       },
       params: RequestParams = {}
     ) => {
-      const { siloName } = path;
       return this.request<SamlIdentityProvider>({
-        path: `/system/silos/${siloName}/identity-providers/saml`,
+        path: `/system/silos/${path.siloName}/identity-providers/saml`,
         method: "POST",
         body,
         ...params,
@@ -4686,9 +4577,8 @@ export class Api extends HttpClient {
       { path }: { path: SamlIdentityProviderViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { providerName, siloName } = path;
       return this.request<SamlIdentityProvider>({
-        path: `/system/silos/${siloName}/identity-providers/saml/${providerName}`,
+        path: `/system/silos/${path.siloName}/identity-providers/saml/${path.providerName}`,
         method: "GET",
         ...params,
       });
@@ -4700,9 +4590,8 @@ export class Api extends HttpClient {
       { path }: { path: SiloPolicyViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { siloName } = path;
       return this.request<SiloRolePolicy>({
-        path: `/system/silos/${siloName}/policy`,
+        path: `/system/silos/${path.siloName}/policy`,
         method: "GET",
         ...params,
       });
@@ -4717,9 +4606,8 @@ export class Api extends HttpClient {
       }: { path: SiloPolicyUpdatePathParams; body: SiloRolePolicy },
       params: RequestParams = {}
     ) => {
-      const { siloName } = path;
       return this.request<SiloRolePolicy>({
-        path: `/system/silos/${siloName}/policy`,
+        path: `/system/silos/${path.siloName}/policy`,
         method: "PUT",
         body,
         ...params,
@@ -4735,9 +4623,8 @@ export class Api extends HttpClient {
       }: { path: SiloUsersListPathParams; query?: SiloUsersListQueryParams },
       params: RequestParams = {}
     ) => {
-      const { siloName } = path;
       return this.request<UserResultsPage>({
-        path: `/system/silos/${siloName}/users/all`,
+        path: `/system/silos/${path.siloName}/users/all`,
         method: "GET",
         query,
         ...params,
@@ -4747,9 +4634,8 @@ export class Api extends HttpClient {
       { path }: { path: SiloUserViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { siloName, userId } = path;
       return this.request<User>({
-        path: `/system/silos/${siloName}/users/id/${userId}`,
+        path: `/system/silos/${path.siloName}/users/id/${path.userId}`,
         method: "GET",
         ...params,
       });
@@ -4785,9 +4671,8 @@ export class Api extends HttpClient {
       { path }: { path: SystemUserViewPathParams },
       params: RequestParams = {}
     ) => {
-      const { userName } = path;
       return this.request<UserBuiltin>({
-        path: `/system/user/${userName}`,
+        path: `/system/user/${path.userName}`,
         method: "GET",
         ...params,
       });

--- a/lib/client/api.ts
+++ b/lib/client/api.ts
@@ -235,14 +235,10 @@ export function generateApi(spec: OpenAPIV3.Document) {
       w("_: EmptyObj,");
     }
 
-    w(` params: RequestParams = {},
-         ) => {`);
-    if (pathParams.length > 0) {
-      w(`const { ${pathParamNames} } = path`);
-    }
-    w(`  return this.request<${successType}>({
-             path: ${pathToTemplateStr(path)},
-             method: "${method.toUpperCase()}",`);
+    w(`params: RequestParams = {}) => {
+         return this.request<${successType}>({
+           path: ${pathToTemplateStr(path)},
+           method: "${method.toUpperCase()}",`);
     if (bodyType) {
       w(`  body,`);
     }

--- a/lib/util.test.ts
+++ b/lib/util.test.ts
@@ -13,7 +13,7 @@ test("pathToTemplateStr", () => {
       "/organizations/{organization_name}/projects/{project_name}/disks/{disk_name}"
     )
   ).toEqual(
-    "`/organizations/${orgName}/projects/${projectName}/disks/${diskName}`"
+    "`/organizations/${path.orgName}/projects/${path.projectName}/disks/${path.diskName}`"
   );
 });
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -11,14 +11,8 @@ export const snakeToCamel = snakeTo((w, i) => (i > 0 ? cap(w) : w));
 export const pascalToCamel = (s: string) =>
   s ? s[0].toLowerCase() + s.slice(1) : s;
 
-// HACK: we will probably do this rename in Nexus at some point because
-// "organization" is really long. Luckily it is only ever used as an
-// interpolated variable in request paths, so renaming it is fine as long
-// as we do it everywhere.
-
 const renameMap: Record<string, string> = {
   organization_name: "org_name",
-  interface: "iface",
 };
 
 const renameParam = (s: string) => renameMap[s] || s;
@@ -27,7 +21,7 @@ export const processParamName = (s: string) => snakeToCamel(renameParam(s));
 
 /** `{project_name}` -> `${projectName}`. if no brackets, leave it alone */
 const segmentToInterpolation = (s: string) =>
-  s.startsWith("{") ? `\$\{${processParamName(s.slice(1, -1))}\}` : s;
+  s.startsWith("{") ? `\$\{path.${processParamName(s.slice(1, -1))}\}` : s;
 
 export const pathToTemplateStr = (s: string) =>
   "`" + s.split("/").map(segmentToInterpolation).join("/") + "`";


### PR DESCRIPTION
The network interface `NameOrId` param is called `interface`, which TS doesn't like because it's a reserved word. We could rename it on the API side or we could handle it here like this.

![image](https://user-images.githubusercontent.com/3612203/219537637-52aa885f-e8ef-43bc-a753-1c160a798abb.png)
