### PR TITLE
Handle websockets endpoints differently

### DIFF
--- a/client/Api.ts
+++ b/client/Api.ts
@@ -7985,11 +7985,7 @@ export class Api extends HttpClient {
       }
     ) => {
       let route = `/v1/instances/${path.instance}/serial-console/stream`;
-      const queryString = toQueryString(query);
-      if (queryString) {
-        route += "?" + queryString;
-      }
-      return new WebSocket("ws://" + host + route);
+      return new WebSocket("ws://" + host + route + toQueryString(query));
     },
   };
 }

--- a/client/http-client.ts
+++ b/client/http-client.ts
@@ -79,9 +79,9 @@ function encodeQueryParam(key: string, value: unknown) {
   )}`;
 }
 
-// params with null value are filtered out
-export const toQueryString = (rawQuery?: QueryParamsType): string =>
-  Object.entries(rawQuery || {})
+/** Query params with null values filtered out. `"?"` included. */
+export function toQueryString(rawQuery?: QueryParamsType): string {
+  const qs = Object.entries(rawQuery || {})
     .filter(([_key, value]) => isNotNull(value))
     .map(([key, value]) =>
       Array.isArray(value)
@@ -89,6 +89,8 @@ export const toQueryString = (rawQuery?: QueryParamsType): string =>
         : encodeQueryParam(key, value)
     )
     .join("&");
+  return qs ? "?" + qs : "";
+}
 
 export async function handleResponse<Data>(
   response: Response
@@ -162,13 +164,8 @@ export class HttpClient {
     ...params
   }: FullRequestParams): Promise<ApiResult<Data>> => {
     const requestParams = this.mergeRequestParams(params);
-    const queryString = query && toQueryString(query);
 
-    let url = baseUrl || this.baseUrl || "";
-    url += path;
-    if (queryString) {
-      url += "?" + queryString;
-    }
+    const url = (baseUrl || this.baseUrl || "") + path + toQueryString(query);
 
     const response = await fetch(url, {
       ...requestParams,

--- a/lib/client/api.ts
+++ b/lib/client/api.ts
@@ -293,13 +293,9 @@ export function generateApi(spec: OpenAPIV3.Document) {
     // websocket endpoints can't use normal fetch so we return a WebSocket
     w(`) => {
         let route = ${pathToTemplateStr(path)}`);
-    if (queryParams.length > 0) {
-      w(`const queryString = toQueryString(query)
-         if (queryString) {
-           route += "?" + queryString;
-         }`);
-    }
-    w(`return new WebSocket('ws://' + host + route);
+    w0(`return new WebSocket('ws://' + host + route`);
+    if (queryParams.length > 0) w0(`+ toQueryString(query)`);
+    w(`);
      },`);
   }
 

--- a/static/http-client.ts
+++ b/static/http-client.ts
@@ -79,9 +79,9 @@ function encodeQueryParam(key: string, value: unknown) {
   )}`;
 }
 
-// params with null value are filtered out
-export const toQueryString = (rawQuery?: QueryParamsType): string =>
-  Object.entries(rawQuery || {})
+/** Query params with null values filtered out. `"?"` included. */
+export function toQueryString(rawQuery?: QueryParamsType): string {
+  const qs = Object.entries(rawQuery || {})
     .filter(([_key, value]) => isNotNull(value))
     .map(([key, value]) =>
       Array.isArray(value)
@@ -89,6 +89,8 @@ export const toQueryString = (rawQuery?: QueryParamsType): string =>
         : encodeQueryParam(key, value)
     )
     .join("&");
+  return qs ? "?" + qs : "";
+}
 
 export async function handleResponse<Data>(
   response: Response
@@ -162,13 +164,8 @@ export class HttpClient {
     ...params
   }: FullRequestParams): Promise<ApiResult<Data>> => {
     const requestParams = this.mergeRequestParams(params);
-    const queryString = query && toQueryString(query);
 
-    let url = baseUrl || this.baseUrl || "";
-    url += path;
-    if (queryString) {
-      url += "?" + queryString;
-    }
+    const url = (baseUrl || this.baseUrl || "") + path + toQueryString(query);
 
     const response = await fetch(url, {
       ...requestParams,


### PR DESCRIPTION
Add `api.ws` alongside `api.methods` to make constructing the `WebSocket` less manual in the console. Not sure we need this but it seems handy. This is the console change enabled by this change:

<img width="880" alt="image" src="https://user-images.githubusercontent.com/3612203/225438859-dc0e7a69-a457-49ee-b906-bd0559ef5d77.png">
