### PR TITLE
Add copyright line to license header

### DIFF
--- a/client/Api.ts
+++ b/client/Api.ts
@@ -4,6 +4,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import type { RequestParams } from "./http-client";

--- a/client/http-client.ts
+++ b/client/http-client.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { camelToSnake, processResponseBody, snakeify, isNotNull } from "./util";

--- a/client/msw-handlers.ts
+++ b/client/msw-handlers.ts
@@ -4,6 +4,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import {

--- a/client/type-test.ts
+++ b/client/type-test.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { z } from "zod";

--- a/client/util.ts
+++ b/client/util.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 export const camelToSnake = (s: string) =>

--- a/client/validate.ts
+++ b/client/validate.ts
@@ -4,6 +4,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { z, ZodType } from "zod";

--- a/lib/client/api.ts
+++ b/lib/client/api.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import type { OpenAPIV3 } from "openapi-types";
@@ -69,6 +71,8 @@ export function generateApi(spec: OpenAPIV3.Document) {
      * This Source Code Form is subject to the terms of the Mozilla Public
      * License, v. 2.0. If a copy of the MPL was not distributed with this
      * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+     *
+     * Copyright Oxide Computer Company
      */
   `);
 

--- a/lib/client/base.ts
+++ b/lib/client/base.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { OpenAPIV3 } from "openapi-types";

--- a/lib/client/msw-handlers.ts
+++ b/lib/client/msw-handlers.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import type { OpenAPIV3 } from "openapi-types";
@@ -27,6 +29,8 @@ export function generateMSWHandlers(spec: OpenAPIV3.Document) {
      * This Source Code Form is subject to the terms of the Mozilla Public
      * License, v. 2.0. If a copy of the MPL was not distributed with this
      * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+     *
+     * Copyright Oxide Computer Company
      */
   `);
 

--- a/lib/client/type-tests.ts
+++ b/lib/client/type-tests.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { OpenAPIV3 } from "openapi-types";
@@ -21,6 +23,8 @@ export function generateTypeTests(spec: OpenAPIV3.Document) {
      * This Source Code Form is subject to the terms of the Mozilla Public
      * License, v. 2.0. If a copy of the MPL was not distributed with this
      * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+     *
+     * Copyright Oxide Computer Company
      */
   `);
 

--- a/lib/client/zodValidators.ts
+++ b/lib/client/zodValidators.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { OpenAPIV3 } from "openapi-types";
@@ -24,6 +26,8 @@ export function generateZodValidators(spec: OpenAPIV3.Document) {
    * This Source Code Form is subject to the terms of the Mozilla Public
    * License, v. 2.0. If a copy of the MPL was not distributed with this
    * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+   *
+   * Copyright Oxide Computer Company
    */
 
   import { z, ZodType } from 'zod';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import SwaggerParser from "@apidevtools/swagger-parser";

--- a/lib/io.ts
+++ b/lib/io.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import path from "path";

--- a/lib/schema/base.ts
+++ b/lib/schema/base.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { match, P } from "ts-pattern";

--- a/lib/schema/types.ts
+++ b/lib/schema/types.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { snakeToCamel } from "../util";

--- a/lib/schema/zod.test.ts
+++ b/lib/schema/zod.test.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { expect, test, beforeEach } from "vitest";

--- a/lib/schema/zod.ts
+++ b/lib/schema/zod.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { IO } from "../io";

--- a/lib/util.test.ts
+++ b/lib/util.test.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { OpenAPIV3 } from "openapi-types";

--- a/static/http-client.test.ts
+++ b/static/http-client.test.ts
@@ -4,6 +4,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { handleResponse } from "./http-client";

--- a/static/http-client.ts
+++ b/static/http-client.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { camelToSnake, processResponseBody, snakeify, isNotNull } from "./util";

--- a/static/util.test.ts
+++ b/static/util.test.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import {

--- a/static/util.ts
+++ b/static/util.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 export const camelToSnake = (s: string) =>

--- a/tests/helpers/schema.ts
+++ b/tests/helpers/schema.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import SwaggerParser from "@apidevtools/swagger-parser";

--- a/tests/known-properties.test.ts
+++ b/tests/known-properties.test.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { test, describe, expect } from "vitest";

--- a/tests/validate-publish.test.ts
+++ b/tests/validate-publish.test.ts
@@ -2,6 +2,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
  */
 
 import { test, expect } from "vitest";

--- a/tools/gen.sh
+++ b/tools/gen.sh
@@ -3,6 +3,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright Oxide Computer Company
 
 set -o errexit
 set -o pipefail


### PR DESCRIPTION
Look ma!

```sh
rg --files-with-matches 'you can obtain one' | 
xargs -I _ sed -i '' '/you can obtain one/a\
 *\
 * Copyright Oxide Computer Company\
' _
```

Had to fix the indents on the quoted ones in the generator code, but that was pretty good.