### PR TITLE
Include response directly on `ApiResult`

### DIFF
--- a/client/http-client.ts
+++ b/client/http-client.ts
@@ -11,8 +11,7 @@ import { camelToSnake, processResponseBody, snakeify, isNotNull } from "./util";
 /** Success responses from the API */
 export type ApiSuccess<Data> = {
   type: "success";
-  statusCode: number;
-  headers: Headers;
+  response: Response;
   data: Data;
 };
 
@@ -29,17 +28,15 @@ export type ErrorResult =
   // 4xx and 5xx responses from the API
   | {
       type: "error";
-      statusCode: number;
-      headers: Headers;
+      response: Response;
       data: ErrorBody;
     }
   // JSON parsing or processing errors within the client. Includes raised Error
   // and response body as a string for debugging.
   | {
       type: "client_error";
+      response: Response;
       error: Error;
-      statusCode: number;
-      headers: Headers;
       text: string;
     };
 
@@ -66,8 +63,6 @@ function encodeQueryParam(key: string, value: unknown) {
 export async function handleResponse<Data>(
   response: Response
 ): Promise<ApiResult<Data>> {
-  const common = { statusCode: response.status, headers: response.headers };
-
   const respText = await response.text();
 
   // catch JSON parse or processing errors
@@ -80,25 +75,25 @@ export async function handleResponse<Data>(
   } catch (e) {
     return {
       type: "client_error",
+      response,
       error: e as Error,
       text: respText,
-      ...common,
     };
   }
 
   if (!response.ok) {
     return {
       type: "error",
+      response,
       data: respJson as ErrorBody,
-      ...common,
     };
   }
 
   // don't validate respJson, just assume it matches the type
   return {
     type: "success",
+    response,
     data: respJson as Data,
-    ...common,
   };
 }
 

--- a/static/http-client.test.ts
+++ b/static/http-client.test.ts
@@ -19,59 +19,61 @@ const json = (body: any, status = 200) =>
 
 describe("handleResponse", () => {
   it("handles success", async () => {
-    const result = await handleResponse(json({ abc: 123 }));
-    expect(result).toMatchObject({
+    const { response, ...rest } = await handleResponse(json({ abc: 123 }));
+    expect(rest).toMatchObject({
       data: { abc: 123 },
-      statusCode: 200,
       type: "success",
     });
-    expect(result.headers.get("Content-Type")).toBe("application/json");
+    expect(response.status).toEqual(200);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
   });
 
   it('API error returns type "error"', async () => {
-    const result = await handleResponse(json({ bad_stuff: "hi" }, 400));
-    expect(result).toMatchObject({
+    const { response, ...rest } = await handleResponse(
+      json({ bad_stuff: "hi" }, 400)
+    );
+    expect(rest).toMatchObject({
       data: { badStuff: "hi" },
-      statusCode: 400,
       type: "error",
     });
-    expect(result.headers.get("Content-Type")).toBe("application/json");
+    expect(response.status).toEqual(400);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
   });
 
   it("non-json response causes client_error w/ text and error", async () => {
     const resp = new Response("not json", { headers });
-    const result = await handleResponse(resp);
-    expect(result).toMatchObject({
+    const { response, ...rest } = await handleResponse(resp);
+    expect(rest).toMatchObject({
       error: expect.any(SyntaxError),
-      statusCode: 200,
       text: "not json",
       type: "client_error",
     });
-    expect(result.headers.get("Content-Type")).toBe("application/json");
+    expect(response.status).toEqual(200);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
   });
 
   it("parses dates and converts to camel case", async () => {
     const resp = json({ time_created: "2022-05-01" });
-    const result = await handleResponse(resp);
-    expect(result).toMatchObject({
+    const { response, ...rest } = await handleResponse(resp);
+    expect(rest).toMatchObject({
       type: "success",
       data: {
         timeCreated: new Date(Date.UTC(2022, 4, 1)),
       },
     });
-    expect(result.headers.get("Content-Type")).toBe("application/json");
+    expect(response.headers.get("Content-Type")).toBe("application/json");
   });
 
   it("leaves unparseable dates alone", async () => {
     const resp = json({ time_created: "abc" });
-    const result = await handleResponse(resp);
-    expect(result).toMatchObject({
+    const { response, ...rest } = await handleResponse(resp);
+    expect(rest).toMatchObject({
       type: "success",
       data: {
         timeCreated: "abc",
       },
     });
-    expect(result.headers.get("Content-Type")).toBe("application/json");
+    expect(response.headers.get("Content-Type")).toBe("application/json");
   });
 });
 

--- a/static/http-client.ts
+++ b/static/http-client.ts
@@ -11,8 +11,7 @@ import { camelToSnake, processResponseBody, snakeify, isNotNull } from "./util";
 /** Success responses from the API */
 export type ApiSuccess<Data> = {
   type: "success";
-  statusCode: number;
-  headers: Headers;
+  response: Response;
   data: Data;
 };
 
@@ -29,17 +28,15 @@ export type ErrorResult =
   // 4xx and 5xx responses from the API
   | {
       type: "error";
-      statusCode: number;
-      headers: Headers;
+      response: Response;
       data: ErrorBody;
     }
   // JSON parsing or processing errors within the client. Includes raised Error
   // and response body as a string for debugging.
   | {
       type: "client_error";
+      response: Response;
       error: Error;
-      statusCode: number;
-      headers: Headers;
       text: string;
     };
 
@@ -66,8 +63,6 @@ function encodeQueryParam(key: string, value: unknown) {
 export async function handleResponse<Data>(
   response: Response
 ): Promise<ApiResult<Data>> {
-  const common = { statusCode: response.status, headers: response.headers };
-
   const respText = await response.text();
 
   // catch JSON parse or processing errors
@@ -80,25 +75,25 @@ export async function handleResponse<Data>(
   } catch (e) {
     return {
       type: "client_error",
+      response,
       error: e as Error,
       text: respText,
-      ...common,
     };
   }
 
   if (!response.ok) {
     return {
       type: "error",
+      response,
       data: respJson as ErrorBody,
-      ...common,
     };
   }
 
   // don't validate respJson, just assume it matches the type
   return {
     type: "success",
+    response,
     data: respJson as Data,
-    ...common,
   };
 }
 


### PR DESCRIPTION
Validated in https://github.com/oxidecomputer/console/pull/2131.