### PR TITLE
`query` shouldn't be optional if there are any required params

### DIFF
--- a/oxide-api/package-lock.json
+++ b/oxide-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/api",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/api",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-alpha.4",
       "license": "MPL-2.0",
       "dependencies": {
         "zod": "^3.23.6"

--- a/oxide-api/package.json
+++ b/oxide-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/api",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "TypeScript client for the Oxide API",
   "engines": {
     "node": ">=18"

--- a/oxide-api/src/Api.ts
+++ b/oxide-api/src/Api.ts
@@ -4229,7 +4229,7 @@ export class Api extends HttpClient {
      * Create instrumentation probe
      */
     probeCreate: (
-      { query, body }: { query?: ProbeCreateQueryParams; body: ProbeCreate },
+      { query, body }: { query: ProbeCreateQueryParams; body: ProbeCreate },
       params: FetchParams = {},
     ) => {
       return this.request<Probe>({
@@ -4247,7 +4247,7 @@ export class Api extends HttpClient {
       {
         path,
         query,
-      }: { path: ProbeViewPathParams; query?: ProbeViewQueryParams },
+      }: { path: ProbeViewPathParams; query: ProbeViewQueryParams },
       params: FetchParams = {},
     ) => {
       return this.request<ProbeInfo>({
@@ -4264,7 +4264,7 @@ export class Api extends HttpClient {
       {
         path,
         query,
-      }: { path: ProbeDeletePathParams; query?: ProbeDeleteQueryParams },
+      }: { path: ProbeDeletePathParams; query: ProbeDeleteQueryParams },
       params: FetchParams = {},
     ) => {
       return this.request<void>({
@@ -4359,7 +4359,7 @@ export class Api extends HttpClient {
      * Create a disk
      */
     diskCreate: (
-      { query, body }: { query?: DiskCreateQueryParams; body: DiskCreate },
+      { query, body }: { query: DiskCreateQueryParams; body: DiskCreate },
       params: FetchParams = {},
     ) => {
       return this.request<Disk>({
@@ -4531,7 +4531,7 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: { query?: FloatingIpCreateQueryParams; body: FloatingIpCreate },
+      }: { query: FloatingIpCreateQueryParams; body: FloatingIpCreate },
       params: FetchParams = {},
     ) => {
       return this.request<FloatingIp>({
@@ -4745,7 +4745,7 @@ export class Api extends HttpClient {
       {
         path,
         query,
-      }: { path: ImageDemotePathParams; query?: ImageDemoteQueryParams },
+      }: { path: ImageDemotePathParams; query: ImageDemoteQueryParams },
       params: FetchParams = {},
     ) => {
       return this.request<Image>({
@@ -4793,7 +4793,7 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: { query?: InstanceCreateQueryParams; body: InstanceCreate },
+      }: { query: InstanceCreateQueryParams; body: InstanceCreate },
       params: FetchParams = {},
     ) => {
       return this.request<Instance>({
@@ -5252,7 +5252,7 @@ export class Api extends HttpClient {
         query,
         body,
       }: {
-        query?: InstanceNetworkInterfaceCreateQueryParams;
+        query: InstanceNetworkInterfaceCreateQueryParams;
         body: InstanceNetworkInterfaceCreate;
       },
       params: FetchParams = {},
@@ -5481,7 +5481,7 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: { query?: SnapshotCreateQueryParams; body: SnapshotCreate },
+      }: { query: SnapshotCreateQueryParams; body: SnapshotCreate },
       params: FetchParams = {},
     ) => {
       return this.request<Snapshot>({
@@ -5706,7 +5706,7 @@ export class Api extends HttpClient {
         body,
       }: {
         path: NetworkingSwitchPortApplySettingsPathParams;
-        query?: NetworkingSwitchPortApplySettingsQueryParams;
+        query: NetworkingSwitchPortApplySettingsQueryParams;
         body: SwitchPortApplySettings;
       },
       params: FetchParams = {},
@@ -5728,7 +5728,7 @@ export class Api extends HttpClient {
         query,
       }: {
         path: NetworkingSwitchPortClearSettingsPathParams;
-        query?: NetworkingSwitchPortClearSettingsQueryParams;
+        query: NetworkingSwitchPortClearSettingsQueryParams;
       },
       params: FetchParams = {},
     ) => {
@@ -5787,7 +5787,7 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: { query?: LocalIdpUserCreateQueryParams; body: UserCreate },
+      }: { query: LocalIdpUserCreateQueryParams; body: UserCreate },
       params: FetchParams = {},
     ) => {
       return this.request<User>({
@@ -5807,7 +5807,7 @@ export class Api extends HttpClient {
         query,
       }: {
         path: LocalIdpUserDeletePathParams;
-        query?: LocalIdpUserDeleteQueryParams;
+        query: LocalIdpUserDeleteQueryParams;
       },
       params: FetchParams = {},
     ) => {
@@ -5828,7 +5828,7 @@ export class Api extends HttpClient {
         body,
       }: {
         path: LocalIdpUserSetPasswordPathParams;
-        query?: LocalIdpUserSetPasswordQueryParams;
+        query: LocalIdpUserSetPasswordQueryParams;
         body: UserPassword;
       },
       params: FetchParams = {},
@@ -5849,7 +5849,7 @@ export class Api extends HttpClient {
         query,
         body,
       }: {
-        query?: SamlIdentityProviderCreateQueryParams;
+        query: SamlIdentityProviderCreateQueryParams;
         body: SamlIdentityProviderCreate;
       },
       params: FetchParams = {},
@@ -5871,7 +5871,7 @@ export class Api extends HttpClient {
         query,
       }: {
         path: SamlIdentityProviderViewPathParams;
-        query?: SamlIdentityProviderViewQueryParams;
+        query: SamlIdentityProviderViewQueryParams;
       },
       params: FetchParams = {},
     ) => {
@@ -6259,7 +6259,7 @@ export class Api extends HttpClient {
      * Delete BGP configuration
      */
     networkingBgpConfigDelete: (
-      { query }: { query?: NetworkingBgpConfigDeleteQueryParams },
+      { query }: { query: NetworkingBgpConfigDeleteQueryParams },
       params: FetchParams = {},
     ) => {
       return this.request<void>({
@@ -6273,7 +6273,7 @@ export class Api extends HttpClient {
      * Get originated routes for a BGP configuration
      */
     networkingBgpAnnounceSetList: (
-      { query }: { query?: NetworkingBgpAnnounceSetListQueryParams },
+      { query }: { query: NetworkingBgpAnnounceSetListQueryParams },
       params: FetchParams = {},
     ) => {
       return this.request<BgpAnnouncement[]>({
@@ -6301,7 +6301,7 @@ export class Api extends HttpClient {
      * Delete BGP announce set
      */
     networkingBgpAnnounceSetDelete: (
-      { query }: { query?: NetworkingBgpAnnounceSetDeleteQueryParams },
+      { query }: { query: NetworkingBgpAnnounceSetDeleteQueryParams },
       params: FetchParams = {},
     ) => {
       return this.request<void>({
@@ -6315,7 +6315,7 @@ export class Api extends HttpClient {
      * Get imported IPv4 BGP routes
      */
     networkingBgpImportedRoutesIpv4: (
-      { query }: { query?: NetworkingBgpImportedRoutesIpv4QueryParams },
+      { query }: { query: NetworkingBgpImportedRoutesIpv4QueryParams },
       params: FetchParams = {},
     ) => {
       return this.request<BgpImportedRouteIpv4[]>({
@@ -6645,7 +6645,7 @@ export class Api extends HttpClient {
       {
         path,
         query,
-      }: { path: SiloUserViewPathParams; query?: SiloUserViewQueryParams },
+      }: { path: SiloUserViewPathParams; query: SiloUserViewQueryParams },
       params: FetchParams = {},
     ) => {
       return this.request<User>({
@@ -6737,7 +6737,7 @@ export class Api extends HttpClient {
      * List firewall rules
      */
     vpcFirewallRulesView: (
-      { query }: { query?: VpcFirewallRulesViewQueryParams },
+      { query }: { query: VpcFirewallRulesViewQueryParams },
       params: FetchParams = {},
     ) => {
       return this.request<VpcFirewallRules>({
@@ -6755,7 +6755,7 @@ export class Api extends HttpClient {
         query,
         body,
       }: {
-        query?: VpcFirewallRulesUpdateQueryParams;
+        query: VpcFirewallRulesUpdateQueryParams;
         body: VpcFirewallRuleUpdateParams;
       },
       params: FetchParams = {},
@@ -6789,7 +6789,7 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: { query?: VpcSubnetCreateQueryParams; body: VpcSubnetCreate },
+      }: { query: VpcSubnetCreateQueryParams; body: VpcSubnetCreate },
       params: FetchParams = {},
     ) => {
       return this.request<VpcSubnet>({
@@ -6898,7 +6898,7 @@ export class Api extends HttpClient {
      * Create VPC
      */
     vpcCreate: (
-      { query, body }: { query?: VpcCreateQueryParams; body: VpcCreate },
+      { query, body }: { query: VpcCreateQueryParams; body: VpcCreate },
       params: FetchParams = {},
     ) => {
       return this.request<Vpc>({

--- a/oxide-openapi-gen-ts/package-lock.json
+++ b/oxide-openapi-gen-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/openapi-gen-ts",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/openapi-gen-ts",
-      "version": "0.1.14",
+      "version": "0.2.0",
       "license": "MPL-2.0",
       "dependencies": {
         "minimist": "^1.2.8",

--- a/oxide-openapi-gen-ts/package.json
+++ b/oxide-openapi-gen-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/openapi-gen-ts",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "OpenAPI client generator used to generate Oxide TypeScript SDK",
   "keywords": [
     "oxide",

--- a/oxide-openapi-gen-ts/src/client/api.ts
+++ b/oxide-openapi-gen-ts/src/client/api.ts
@@ -256,7 +256,9 @@ export function generateApi(spec: OpenAPIV3.Document, destDir: string) {
       }
 
       if (queryParams.length > 0) {
-        w(`query?: ${queryParamsType(methodNameType)},`);
+        w0("query");
+        if (!queryParams.some((p) => p.required)) w0("?");
+        w(`: ${queryParamsType(methodNameType)},`);
       }
       if (bodyType) w(`body: ${bodyType},`);
       w("},");


### PR DESCRIPTION
I noticed that there were cases where the `query` param should be required because there were required query args (like `project` on instance create).

This is a minor version to the generator because it results in a meaningful change to the generated output. I haven't figured out the versioning scheme for `@oxide/api`, so I'll just bump the alpha number.