### PR TITLE
Generator and client: make `Api` a default export

### DIFF
--- a/oxide-api/package-lock.json
+++ b/oxide-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/api",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/api",
-      "version": "0.1.0-alpha.5",
+      "version": "0.1.0-alpha.6",
       "license": "MPL-2.0",
       "devDependencies": {
         "tsup": "^8.0.2",

--- a/oxide-api/package.json
+++ b/oxide-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/api",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "TypeScript client for the Oxide API",
   "engines": {
     "node": ">=18"

--- a/oxide-api/src/Api.ts
+++ b/oxide-api/src/Api.ts
@@ -4175,7 +4175,7 @@ export type ApiListMethods = Pick<
 >;
 
 type EmptyObj = Record<string, never>;
-export class Api extends HttpClient {
+export default class Api extends HttpClient {
   methods = {
     /**
      * Start an OAuth 2.0 Device Authorization Grant

--- a/oxide-openapi-gen-ts/package-lock.json
+++ b/oxide-openapi-gen-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/openapi-gen-ts",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/openapi-gen-ts",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "minimist": "^1.2.8",

--- a/oxide-openapi-gen-ts/package.json
+++ b/oxide-openapi-gen-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/openapi-gen-ts",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "OpenAPI client generator used to generate Oxide TypeScript SDK",
   "keywords": [
     "oxide",

--- a/oxide-openapi-gen-ts/src/client/api.ts
+++ b/oxide-openapi-gen-ts/src/client/api.ts
@@ -207,7 +207,7 @@ export function generateApi(spec: OpenAPIV3.Document, destDir: string) {
 
   w("type EmptyObj = Record<string, never>;");
 
-  w(`export class Api extends HttpClient {
+  w(`export default class Api extends HttpClient {
        methods = {`);
 
   for (const { conf, opId, method, path } of iterPathConfig(spec.paths)) {


### PR DESCRIPTION
Closes #243. Enables

```ts
import Oxide from '@oxide/api'
```

instead of making the user rename it if they want to:

```ts
import { Api as Oxide } from '@oxide/api'
```