### PR TITLE
Fix `Api` export to do both default and named

### DIFF
--- a/oxide-api/package-lock.json
+++ b/oxide-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/api",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/api",
-      "version": "0.1.0-alpha.7",
+      "version": "0.1.0-alpha.8",
       "license": "MPL-2.0",
       "devDependencies": {
         "tsup": "^8.0.2",

--- a/oxide-api/package.json
+++ b/oxide-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/api",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "TypeScript client for the Oxide API",
   "engines": {
     "node": ">=18"

--- a/oxide-api/src/Api.ts
+++ b/oxide-api/src/Api.ts
@@ -4175,7 +4175,7 @@ export type ApiListMethods = Pick<
 >;
 
 type EmptyObj = Record<string, never>;
-export default class Api extends HttpClient {
+export class Api extends HttpClient {
   methods = {
     /**
      * Start an OAuth 2.0 Device Authorization Grant
@@ -6990,3 +6990,5 @@ export default class Api extends HttpClient {
     },
   };
 }
+
+export default Api;

--- a/oxide-openapi-gen-ts/package-lock.json
+++ b/oxide-openapi-gen-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/openapi-gen-ts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/openapi-gen-ts",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MPL-2.0",
       "dependencies": {
         "minimist": "^1.2.8",

--- a/oxide-openapi-gen-ts/package.json
+++ b/oxide-openapi-gen-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/openapi-gen-ts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "OpenAPI client generator used to generate Oxide TypeScript SDK",
   "keywords": [
     "oxide",

--- a/oxide-openapi-gen-ts/src/client/api.ts
+++ b/oxide-openapi-gen-ts/src/client/api.ts
@@ -207,7 +207,7 @@ export function generateApi(spec: OpenAPIV3.Document, destDir: string) {
 
   w("type EmptyObj = Record<string, never>;");
 
-  w(`export default class Api extends HttpClient {
+  w(`export class Api extends HttpClient {
        methods = {`);
 
   for (const { conf, opId, method, path } of iterPathConfig(spec.paths)) {
@@ -331,6 +331,8 @@ export function generateApi(spec: OpenAPIV3.Document, destDir: string) {
   }
 
   w(`  }
-     }`);
+     }
+
+   export default Api;`);
   out.end();
 }


### PR DESCRIPTION
I thought #256 was a patch bump because it theoretically only added a default export. I made a mistake though — I changed the export to default instead of adding a default export alongside the regular export. Then when I bumped the version of `@oxide/openapi-gen-ts` in the console, everything broke because it expected the named export. So this change fixes that. I'm keeping it a patch version because the damage is already done on the previous version bump.