### PR TITLE
Make zod parsing failures look more like real API 400s

### DIFF
--- a/oxide-openapi-gen-ts/package-lock.json
+++ b/oxide-openapi-gen-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/openapi-gen-ts",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/openapi-gen-ts",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MPL-2.0",
       "dependencies": {
         "minimist": "^1.2.8",

--- a/oxide-openapi-gen-ts/package.json
+++ b/oxide-openapi-gen-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/openapi-gen-ts",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "OpenAPI client generator used to generate Oxide TypeScript SDK",
   "keywords": [
     "oxide",


### PR DESCRIPTION
Closes #228

I also removed the ability to handle functions through from handlers by calling them — I think that's an antipattern and I've removed all the spots in the console where we throw uncalled functions.

This will be a minor version bump for the generator because it changes the semantics of generated code, but there is no regen required for the client versioned in this repo because the mock server is not included in that.