### PR TITLE
Allow supplying a retry handler to generated API clients

### DIFF
--- a/oxide-openapi-gen-ts/src/client/static/http-client.ts
+++ b/oxide-openapi-gen-ts/src/client/static/http-client.ts
@@ -117,6 +117,8 @@ export interface FullParams extends FetchParams {
   method?: string;
 }
 
+export type RetryHandler = (url: RequestInfo | URL, init: RequestInit, err: any) => boolean;
+
 export interface ApiConfig {
   /**
    * No host means requests will be sent to the current host. This is used in
@@ -125,14 +127,16 @@ export interface ApiConfig {
   host?: string;
   token?: string;
   baseParams?: FetchParams;
+  retryHandler?: RetryHandler;
 }
 
 export class HttpClient {
   host: string;
   token?: string;
   baseParams: FetchParams;
+  retryHandler: RetryHandler;
 
-  constructor({ host = "", baseParams = {}, token }: ApiConfig = {}) {
+  constructor({ host = "", baseParams = {}, token, retryHandler }: ApiConfig = {}) {
     this.host = host;
     this.token = token;
 
@@ -141,6 +145,7 @@ export class HttpClient {
       headers.append("Authorization", `Bearer ${token}`);
     }
     this.baseParams = mergeParams({ headers }, baseParams);
+    this.retryHandler = retryHandler ? retryHandler : () => false;
   }
 
   public async request<Data>({
@@ -155,7 +160,19 @@ export class HttpClient {
       ...mergeParams(this.baseParams, fetchParams),
       body: JSON.stringify(snakeify(body), replacer),
     };
+    return fetchWithRetry(fetch, url, init, this.retryHandler)
+  }
+}
+
+export async function fetchWithRetry<Data>(fetch: any, url: string, init: RequestInit, retry: RetryHandler): Promise<ApiResult<Data>> {
+  try {
     return handleResponse(await fetch(url, init));
+  } catch (err) {
+    if (retry(url, init, err)) {
+      return await fetchWithRetry(fetch, url, init, retry)
+    }
+
+    throw err
   }
 }
 

--- a/oxide-openapi-gen-ts/src/client/static/http-client.ts
+++ b/oxide-openapi-gen-ts/src/client/static/http-client.ts
@@ -117,7 +117,8 @@ export interface FullParams extends FetchParams {
   method?: string;
 }
 
-export type RetryHandler = (url: RequestInfo | URL, init: RequestInit, err: any) => boolean;
+export type RetryHandler = (err: any) => boolean;
+export type RetryHandlerFactory = (url: RequestInfo | URL, init: RequestInit) => RetryHandler;
 
 export interface ApiConfig {
   /**
@@ -127,14 +128,14 @@ export interface ApiConfig {
   host?: string;
   token?: string;
   baseParams?: FetchParams;
-  retryHandler?: RetryHandler;
+  retryHandler?: RetryHandlerFactory;
 }
 
 export class HttpClient {
   host: string;
   token?: string;
   baseParams: FetchParams;
-  retryHandler: RetryHandler;
+  retryHandler: RetryHandlerFactory;
 
   constructor({ host = "", baseParams = {}, token, retryHandler }: ApiConfig = {}) {
     this.host = host;
@@ -145,7 +146,7 @@ export class HttpClient {
       headers.append("Authorization", `Bearer ${token}`);
     }
     this.baseParams = mergeParams({ headers }, baseParams);
-    this.retryHandler = retryHandler ? retryHandler : () => false;
+    this.retryHandler = retryHandler ? retryHandler : () => () => false;
   }
 
   public async request<Data>({
@@ -160,7 +161,7 @@ export class HttpClient {
       ...mergeParams(this.baseParams, fetchParams),
       body: JSON.stringify(snakeify(body), replacer),
     };
-    return fetchWithRetry(fetch, url, init, this.retryHandler)
+    return fetchWithRetry(fetch, url, init, this.retryHandler(url, init))
   }
 }
 
@@ -168,7 +169,7 @@ export async function fetchWithRetry<Data>(fetch: any, url: string, init: Reques
   try {
     return handleResponse(await fetch(url, init));
   } catch (err) {
-    if (retry(url, init, err)) {
+    if (retry(err)) {
       return await fetchWithRetry(fetch, url, init, retry)
     }
 


### PR DESCRIPTION
This could be something implemented outside of a client, but it would be nice to have some kind of retry facility within the client itself.

This stemmed from an issue encountered trying to integrate a generated client with the `remix-auth-oauth2` package on Node 19+ over http. Node 19 introduced a change to the default http agent which set the `keepAlive` setting to true, meaning that connections will be re-used by default compared to Node 18.

In the case of our custom OAuth2 strategy, `remix-auth-oauth2` makes its own request to the token endpoint with the `Connection: Close` header, after which we immediately make a request to the same server via the generated client. Since the agent has been configured to re-use connection, we seem to be reusing the socket that has yet to been closed on the client side resulting in the server issuing a reset since it has closed the connection. The generated client does not handle errors from the initial `fetch` request that is made, so this bubbles up to the application.

This PR introduces an optional retry handler that wraps both `fetch` and response errors, allowing API clients to be constructed with customized retry logic based on their needs.

An example of how this may be used in this use case is:
```ts
// Retry a single time when receiving an ECONNRESET
const retryFactory = () => {
  const limit = 1;
  let retries = 0;
  return (err: any) => {
    if (retries < limit && err.type === 'system' && err.errno === 'ECONNRESET' && err.code === 'ECONNRESET') {
      retries += 1
      return true
    } else {
      return false
    }
}
```