### PR TITLE
Parse anything that looks like a date

### DIFF
--- a/oxide-api/src/util.ts
+++ b/oxide-api/src/util.ts
@@ -31,7 +31,7 @@ export const isObjectOrArray = (o: unknown) =>
 export const mapObj =
   (
     kf: (k: string) => string,
-    vf: (k: string | undefined, v: unknown) => unknown = (k, v) => v,
+    vf: (k: string | undefined, v: unknown) => unknown = (_k, v) => v,
   ) =>
   (o: unknown): unknown => {
     if (!isObjectOrArray(o)) return o;
@@ -45,8 +45,14 @@ export const mapObj =
     return newObj;
   };
 
-export const parseIfDate = (k: string | undefined, v: unknown) => {
-  if (typeof v === "string" && (k?.startsWith("time_") || k === "timestamp")) {
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z$/;
+
+/**
+ * Use regex to recognize a likely date and then attempt to parse it. Original
+ * value is passed through if either step fails.
+ */
+export const parseIfDate = (_k: string | undefined, v: unknown) => {
+  if (typeof v === "string" && isoDateRegex.test(v)) {
     const d = new Date(v);
     if (isNaN(d.getTime())) return v;
     return d;

--- a/oxide-openapi-gen-ts/src/client/static/http-client.test.ts
+++ b/oxide-openapi-gen-ts/src/client/static/http-client.test.ts
@@ -53,12 +53,12 @@ describe("handleResponse", () => {
   });
 
   it("parses dates and converts to camel case", async () => {
-    const resp = json({ time_created: "2022-05-01" });
+    const resp = json({ time_created: "2022-05-01T02:03:04Z" });
     const { response, ...rest } = await handleResponse(resp);
     expect(rest).toMatchObject({
       type: "success",
       data: {
-        timeCreated: new Date(Date.UTC(2022, 4, 1)),
+        timeCreated: new Date(Date.UTC(2022, 4, 1, 2, 3, 4)),
       },
     });
     expect(response.headers.get("Content-Type")).toBe("application/json");

--- a/oxide-openapi-gen-ts/src/client/static/util.test.ts
+++ b/oxide-openapi-gen-ts/src/client/static/util.test.ts
@@ -46,7 +46,7 @@ test("isObjectOrArray", () => {
 describe("mapObj", () => {
   const fn = mapObj(
     (k) => k + "_",
-    (k, v) => (typeof v === "number" ? v * 2 : v)
+    (_k, v) => (typeof v === "number" ? v * 2 : v)
   );
 
   it("leaves non-objects alone", () => {
@@ -78,33 +78,23 @@ test("processResponseBody", () => {
 });
 
 describe("parseIfDate", () => {
-  it("passes through non-date values", () => {
-    expect(parseIfDate("abc", 123)).toEqual(123);
-    expect(parseIfDate("abc", "def")).toEqual("def");
+  it.each([
+    123,
+    "def",
+    // missing 0   ↓   here
+    "2021-05-03T05:3:05Z",
+  ])("passes through non-date value %s", (v) => {
+    expect(parseIfDate("abc", v)).toEqual(v);
+    expect(parseIfDate("time_created", v)).toEqual(v);
   });
 
-  const timestamp = 1643092429315;
-  const dateStr = new Date(timestamp).toISOString();
+  it("parses values that pass the regex for dates", () => {
+    const timestamp = 1643092429315;
+    const dateStr = new Date(timestamp).toISOString();
 
-  it("doesn't parse dates if key doesn't start with time_", () => {
-    expect(parseIfDate("abc", dateStr)).toEqual(dateStr);
-  });
-
-  it("parses dates if key starts with time_", () => {
     const value = parseIfDate("time_whatever", dateStr);
     expect(value).toBeInstanceOf(Date);
     expect((value as Date).getTime()).toEqual(timestamp);
-  });
-
-  it("parses dates if key = 'timestamp'", () => {
-    const value = parseIfDate("timestamp", dateStr);
-    expect(value).toBeInstanceOf(Date);
-    expect((value as Date).getTime()).toEqual(timestamp);
-  });
-
-  it("passes through values that fail to parse as dates", () => {
-    const value = parseIfDate("time_whatever", "blah");
-    expect(value).toEqual("blah");
   });
 });
 

--- a/oxide-openapi-gen-ts/src/client/static/util.ts
+++ b/oxide-openapi-gen-ts/src/client/static/util.ts
@@ -31,7 +31,7 @@ export const isObjectOrArray = (o: unknown) =>
 export const mapObj =
   (
     kf: (k: string) => string,
-    vf: (k: string | undefined, v: unknown) => unknown = (k, v) => v
+    vf: (k: string | undefined, v: unknown) => unknown = (_k, v) => v
   ) =>
   (o: unknown): unknown => {
     if (!isObjectOrArray(o)) return o;
@@ -45,8 +45,14 @@ export const mapObj =
     return newObj;
   };
 
-export const parseIfDate = (k: string | undefined, v: unknown) => {
-  if (typeof v === "string" && (k?.startsWith("time_") || k === "timestamp")) {
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z$/;
+
+/**
+ * Use regex to recognize a likely date and then attempt to parse it. Original
+ * value is passed through if either step fails.
+ */
+export const parseIfDate = (_k: string | undefined, v: unknown) => {
+  if (typeof v === "string" && isoDateRegex.test(v)) {
     const d = new Date(v);
     if (isNaN(d.getTime())) return v;
     return d;


### PR DESCRIPTION
This is basically it:

```diff
-if (typeof v === "string" && (k?.startsWith("time_") || k === "timestamp")) {
+if (typeof v === "string" && isoDateRegex.test(v)) {
```

Before this PR, we require a key with a prefix of `time_` or an exact match to `timestamp` in order for us to attempt parsing the value a date. This is pretty bad because there is no reason to expect timestamp properties to follow this pattern — it only happened to be true in [omicron](https://github.com/oxidecomputer/omicron) for a long time. This was already a problem for other apps using this generator that did not follow this very implicit (secret, even) convention, as @augustuswm can attest.

In this PR, instead of looking at the keys, we just parse as a date anything that matches a regex. This is still suboptimal, because it's easy to imagine a value happens to look like a date but which should be left as a string. For example, imagine setting a date as a description on a resource. The description is intrinsically a string and should be left as one, but this approach will cause it to be parsed as a date, even though the generated types will call it a string. This could obviously cause problems in an app.

The difficulty here is that we don't have the OpenAPI schema on hand at runtime. #279 attempts to solve this more robustly by generating code to parse as a date any fields that say `format: date-time` in the OpenAPI schema. However, #279 feels so complicated that I would prefer to find a compromise solution that looks more like this PR.