### PR TITLE
Option 3: add `endsWith('_expiration')` to date conditions

### DIFF
--- a/oxide-api/src/util.ts
+++ b/oxide-api/src/util.ts
@@ -45,8 +45,17 @@ export const mapObj =
     return newObj;
   };
 
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z$/;
+
 export const parseIfDate = (k: string | undefined, v: unknown) => {
-  if (typeof v === "string" && (k?.startsWith("time_") || k === "timestamp")) {
+  if (
+    typeof v === "string" &&
+    isoDateRegex.test(v) &&
+    (k?.startsWith("time_") ||
+      k?.endsWith("_time") ||
+      k?.endsWith("_expiration") ||
+      k === "timestamp")
+  ) {
     const d = new Date(v);
     if (isNaN(d.getTime())) return v;
     return d;

--- a/oxide-openapi-gen-ts/package-lock.json
+++ b/oxide-openapi-gen-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/openapi-gen-ts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/openapi-gen-ts",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "minimist": "^1.2.8",

--- a/oxide-openapi-gen-ts/package.json
+++ b/oxide-openapi-gen-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/openapi-gen-ts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "OpenAPI client generator used to generate Oxide TypeScript SDK",
   "keywords": [
     "oxide",

--- a/oxide-openapi-gen-ts/src/client/static/http-client.test.ts
+++ b/oxide-openapi-gen-ts/src/client/static/http-client.test.ts
@@ -53,12 +53,12 @@ describe("handleResponse", () => {
   });
 
   it("parses dates and converts to camel case", async () => {
-    const resp = json({ time_created: "2022-05-01" });
+    const resp = json({ time_created: "2022-05-01T02:03:04Z" });
     const { response, ...rest } = await handleResponse(resp);
     expect(rest).toMatchObject({
       type: "success",
       data: {
-        timeCreated: new Date(Date.UTC(2022, 4, 1)),
+        timeCreated: new Date(Date.UTC(2022, 4, 1, 2, 3, 4)),
       },
     });
     expect(response.headers.get("Content-Type")).toBe("application/json");

--- a/oxide-openapi-gen-ts/src/client/static/util.test.ts
+++ b/oxide-openapi-gen-ts/src/client/static/util.test.ts
@@ -90,17 +90,14 @@ describe("parseIfDate", () => {
     expect(parseIfDate("abc", dateStr)).toEqual(dateStr);
   });
 
-  it("parses dates if key starts with time_", () => {
-    const value = parseIfDate("time_whatever", dateStr);
-    expect(value).toBeInstanceOf(Date);
-    expect((value as Date).getTime()).toEqual(timestamp);
-  });
-
-  it("parses dates if key = 'timestamp'", () => {
-    const value = parseIfDate("timestamp", dateStr);
-    expect(value).toBeInstanceOf(Date);
-    expect((value as Date).getTime()).toEqual(timestamp);
-  });
+  it.each(["time_whatever", "auto_thing_expiration", "timestamp"])(
+    "parses dates if key is '%s'",
+    (key) => {
+      const value = parseIfDate(key, dateStr);
+      expect(value).toBeInstanceOf(Date);
+      expect((value as Date).getTime()).toEqual(timestamp);
+    }
+  );
 
   it("passes through values that fail to parse as dates", () => {
     const value = parseIfDate("time_whatever", "blah");

--- a/oxide-openapi-gen-ts/src/client/static/util.ts
+++ b/oxide-openapi-gen-ts/src/client/static/util.ts
@@ -45,8 +45,17 @@ export const mapObj =
     return newObj;
   };
 
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z$/;
+
 export const parseIfDate = (k: string | undefined, v: unknown) => {
-  if (typeof v === "string" && (k?.startsWith("time_") || k === "timestamp")) {
+  if (
+    typeof v === "string" &&
+    isoDateRegex.test(v) &&
+    (k?.startsWith("time_") ||
+      k?.endsWith("_time") ||
+      k?.endsWith("_expiration") ||
+      k === "timestamp")
+  ) {
     const d = new Date(v);
     if (isNaN(d.getTime())) return v;
     return d;


### PR DESCRIPTION
This is embarrassing but at least it doesn't mean you can accidentally get a description parsed as a date if you stick a date in it.