### PR TITLE
Remove `ApiListMethods` and `ApiViewByIdMethods`

### DIFF
--- a/oxide-api/src/Api.ts
+++ b/oxide-api/src/Api.ts
@@ -5059,58 +5059,6 @@ export interface VpcDeleteQueryParams {
   project?: NameOrId;
 }
 
-export type ApiListMethods = Pick<
-  InstanceType<typeof Api>["methods"],
-  | "probeList"
-  | "certificateList"
-  | "diskList"
-  | "diskMetricsList"
-  | "floatingIpList"
-  | "groupList"
-  | "imageList"
-  | "instanceList"
-  | "instanceDiskList"
-  | "instanceExternalIpList"
-  | "instanceSshPublicKeyList"
-  | "projectIpPoolList"
-  | "currentUserSshKeyList"
-  | "instanceNetworkInterfaceList"
-  | "projectList"
-  | "snapshotList"
-  | "physicalDiskList"
-  | "rackList"
-  | "sledList"
-  | "sledPhysicalDiskList"
-  | "sledInstanceList"
-  | "networkingSwitchPortList"
-  | "switchList"
-  | "siloIdentityProviderList"
-  | "ipPoolList"
-  | "ipPoolRangeList"
-  | "ipPoolSiloList"
-  | "ipPoolServiceRangeList"
-  | "networkingAddressLotList"
-  | "networkingAddressLotBlockList"
-  | "networkingBgpConfigList"
-  | "networkingBgpAnnounceSetList"
-  | "networkingBgpAnnouncementList"
-  | "networkingLoopbackAddressList"
-  | "networkingSwitchPortSettingsList"
-  | "roleList"
-  | "systemQuotasList"
-  | "siloList"
-  | "siloIpPoolList"
-  | "siloUserList"
-  | "userBuiltinList"
-  | "siloUtilizationList"
-  | "timeseriesSchemaList"
-  | "userList"
-  | "vpcRouterRouteList"
-  | "vpcRouterList"
-  | "vpcSubnetList"
-  | "vpcList"
->;
-
 type EmptyObj = Record<string, never>;
 export class Api extends HttpClient {
   methods = {

--- a/oxide-api/src/util.ts
+++ b/oxide-api/src/util.ts
@@ -31,7 +31,7 @@ export const isObjectOrArray = (o: unknown) =>
 export const mapObj =
   (
     kf: (k: string) => string,
-    vf: (k: string | undefined, v: unknown) => unknown = (k, v) => v,
+    vf: (k: string | undefined, v: unknown) => unknown = (_, v) => v,
   ) =>
   (o: unknown): unknown => {
     if (!isObjectOrArray(o)) return o;

--- a/oxide-openapi-gen-ts/src/client/api.ts
+++ b/oxide-openapi-gen-ts/src/client/api.ts
@@ -158,40 +158,6 @@ export function generateApi(spec: OpenAPIV3.Document, destDir: string) {
     }
   }
 
-  const operations = Object.values(spec.paths)
-    .map((handlers) =>
-      Object.entries(handlers!)
-        .filter(([method]) => method.toUpperCase() in HttpMethods)
-        .map(([_, conf]) => conf)
-    )
-    .flat()
-    .filter((handler) => {
-      return (
-        !!handler && typeof handler === "object" && "operationId" in handler
-      );
-    });
-
-  // TODO: Fix this type
-  const ops = operations as Exclude<
-    typeof operations[number],
-    | string
-    | (OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject)[]
-    | OpenAPIV3.ServerObject[]
-  >[];
-
-  const idRoutes = ops.filter((op) => op.operationId?.endsWith("view_by_id"));
-  if (idRoutes.length > 0) {
-    w(
-      "export type ApiViewByIdMethods = Pick<InstanceType<typeof Api>['methods'], "
-    );
-    w0(
-      `${idRoutes
-        .map((op) => `'${snakeToCamel(op.operationId!)}'`)
-        .join(" | ")}`
-    );
-    w(">\n");
-  }
-
   w("type EmptyObj = Record<string, never>;");
 
   w(`export class Api extends HttpClient {

--- a/oxide-openapi-gen-ts/src/client/api.ts
+++ b/oxide-openapi-gen-ts/src/client/api.ts
@@ -12,8 +12,6 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 import type { OpenAPIV3 } from "openapi-types";
-import { OpenAPIV3 as O } from "openapi-types";
-const HttpMethods = O.HttpMethods;
 import {
   extractDoc,
   pathToTemplateStr,

--- a/oxide-openapi-gen-ts/src/client/api.ts
+++ b/oxide-openapi-gen-ts/src/client/api.ts
@@ -192,19 +192,6 @@ export function generateApi(spec: OpenAPIV3.Document, destDir: string) {
     w(">\n");
   }
 
-  const listRoutes = ops.filter((op) => op.operationId?.match(/_list(_v1)?$/));
-  if (listRoutes.length > 0) {
-    w(
-      "export type ApiListMethods = Pick<InstanceType<typeof Api>['methods'], "
-    );
-    w0(
-      `${listRoutes
-        .map((op) => `'${snakeToCamel(op.operationId!)}'`)
-        .join(" | ")}`
-    );
-    w(">\n");
-  }
-
   w("type EmptyObj = Record<string, never>;");
 
   w(`export class Api extends HttpClient {

--- a/oxide-openapi-gen-ts/src/client/static/util.ts
+++ b/oxide-openapi-gen-ts/src/client/static/util.ts
@@ -31,7 +31,7 @@ export const isObjectOrArray = (o: unknown) =>
 export const mapObj =
   (
     kf: (k: string) => string,
-    vf: (k: string | undefined, v: unknown) => unknown = (k, v) => v
+    vf: (k: string | undefined, v: unknown) => unknown = (_, v) => v
   ) =>
   (o: unknown): unknown => {
     if (!isObjectOrArray(o)) return o;


### PR DESCRIPTION
`ApiListMethods` is no longer needed in the console and is not used in any other app with a generated TS client. `ApiViewByIdMethods` has never been used, as far as I can tell — there are no methods with operation IDs ending with `view_by_id`.