### PR TITLE
Take license and eslint-disable bit out of generator

### DIFF
--- a/oxide-api/src/Api.ts
+++ b/oxide-api/src/Api.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 /**
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,6 +6,7 @@
  * Copyright Oxide Computer Company
  */
 
+/* eslint-disable */
 import type { FetchParams } from "./http-client";
 import { HttpClient, toQueryString } from "./http-client";
 

--- a/oxide-api/src/http-client.ts
+++ b/oxide-api/src/http-client.ts
@@ -6,6 +6,7 @@
  * Copyright Oxide Computer Company
  */
 
+/* eslint-disable */
 import { camelToSnake, processResponseBody, snakeify, isNotNull } from "./util";
 
 /** Success responses from the API */

--- a/oxide-api/src/util.ts
+++ b/oxide-api/src/util.ts
@@ -6,6 +6,7 @@
  * Copyright Oxide Computer Company
  */
 
+/* eslint-disable */
 export const camelToSnake = (s: string) =>
   s.replace(/[A-Z]/g, (l) => "_" + l.toLowerCase());
 

--- a/oxide-openapi-gen-ts/src/client/api.ts
+++ b/oxide-openapi-gen-ts/src/client/api.ts
@@ -124,17 +124,7 @@ export function generateApi(spec: OpenAPIV3.Document, destDir: string) {
   const io = initIO(out);
   const { w, w0 } = io;
 
-  w(`/* eslint-disable */
-
-    /**
-     * This Source Code Form is subject to the terms of the Mozilla Public
-     * License, v. 2.0. If a copy of the MPL was not distributed with this
-     * file, you can obtain one at https://mozilla.org/MPL/2.0/.
-     *
-     * Copyright Oxide Computer Company
-     */
-
-    import type { FetchParams } from './http-client'
+  w(`import type { FetchParams } from './http-client'
     import { HttpClient, toQueryString } from './http-client'
 
     export type { ApiConfig, ApiResult, ErrorBody, ErrorResult, } from './http-client'

--- a/oxide-openapi-gen-ts/src/client/static/http-client.ts
+++ b/oxide-openapi-gen-ts/src/client/static/http-client.ts
@@ -1,11 +1,3 @@
-/**
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at https://mozilla.org/MPL/2.0/.
- *
- * Copyright Oxide Computer Company
- */
-
 import { camelToSnake, processResponseBody, snakeify, isNotNull } from "./util";
 
 /** Success responses from the API */

--- a/oxide-openapi-gen-ts/src/client/static/util.ts
+++ b/oxide-openapi-gen-ts/src/client/static/util.ts
@@ -1,11 +1,3 @@
-/**
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at https://mozilla.org/MPL/2.0/.
- *
- * Copyright Oxide Computer Company
- */
-
 export const camelToSnake = (s: string) =>
   s.replace(/[A-Z]/g, (l) => "_" + l.toLowerCase());
 

--- a/tools/gen.sh
+++ b/tools/gen.sh
@@ -9,6 +9,20 @@
 set -o errexit
 set -o pipefail
 
+HEADER=$(cat <<'EOF'
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+/* eslint-disable */
+
+EOF
+)
+
 ROOT_DIR="$(dirname "$0")/.."
 OMICRON_SHA=$(cat "$ROOT_DIR/OMICRON_VERSION")
 DEST_DIR="$ROOT_DIR/oxide-api/src"
@@ -19,8 +33,14 @@ SPEC_FILE="./spec.json"
 # TODO: we could get rid of this DL if a test didn't rely on it
 curl --fail "$SPEC_URL" -o $SPEC_FILE
 
-rm -f oxide-api/src/* # remove after we add --clean flag to generator
+rm -f "$DEST_DIR/*" # remove after we add --clean flag to generator
 
 # note no features, API client only
 npx tsx "$ROOT_DIR/oxide-openapi-gen-ts/src/index.ts" $SPEC_FILE $DEST_DIR
+
+# prepend HEADER to all generated ts files
+for file in "$DEST_DIR"/*.ts; do
+  printf '%s\n%s' "$HEADER" "$(cat "$file")" > "$file"
+done
+
 npx prettier@3.2.5 --write --log-level error "$DEST_DIR"


### PR DESCRIPTION
The license being stuck in by the generator makes no sense. Let's make it the responsibility of the consumer of the generator to prepend whatever they want. In our case (see `tools/gen.sh`) that is both the license and an `/* eslint-disable */`.

Closes #296