### PR TITLE
Fix readme explanation of where to find token, do a patch bump

### DIFF
--- a/oxide-api/README.md
+++ b/oxide-api/README.md
@@ -16,7 +16,7 @@ Make sure to use the SDK compatible with your Oxide system version.
 
 | System version | `@oxide/api` version | npm tag |
 | --- | --- | --- |
-| [18](https://docs.oxide.computer/release-notes/system/18) | 0.5.0 | `rel18` |
+| [18](https://docs.oxide.computer/release-notes/system/18) | 0.5.1 | `rel18` |
 
 ## Usage
 
@@ -34,11 +34,8 @@ The easiest way to get a device token is to use the CLI.
 oxide auth login --host https://my-oxide-rack.com
 ```
 
-Then print the token:
-
-```
-oxide auth status --show-token
-```
+You can find the generated token in `~/.config/oxide/credentials.toml`
+(`%USERPROFILE%\.config\oxide\credentials.toml` on Windows).
 
 In the following example, the token is passed to the script through the
 `OXIDE_TOKEN` environment variable on the assumption that you don't want to

--- a/oxide-api/package-lock.json
+++ b/oxide-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/api",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/api",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MPL-2.0",
       "devDependencies": {
         "tsup": "^8.0.2",

--- a/oxide-api/package.json
+++ b/oxide-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/api",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "TypeScript client for the Oxide API",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Only way to get the npm readme to update is to release a new version.

oxide.rs uses `dirs::home_dir()` to get cross-platform home dirs. https://docs.rs/dirs/latest/dirs/fn.home_dir.html