### PR TITLE
Wrap API response data in DeepReadonly

### DIFF
--- a/oxide-api/src/http-client.ts
+++ b/oxide-api/src/http-client.ts
@@ -8,11 +8,25 @@
 
 import { camelToSnake, processResponseBody, isNotNull } from "./util";
 
+/**
+ * Recursively mark a type readonly. `Date` is left intact (it's a class, not a
+ * plain data object) and arrays become `ReadonlyArray`. Used to make API
+ * response bodies immutable without touching the request-body types, which
+ * share the same underlying schemas but may be mutated while being built.
+ */
+export type DeepReadonly<T> = T extends Date
+  ? T
+  : T extends (infer U)[]
+    ? ReadonlyArray<DeepReadonly<U>>
+    : T extends object
+      ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+      : T;
+
 /** Success responses from the API */
 export type ApiSuccess<Data> = {
   type: "success";
   response: Response;
-  data: Data;
+  data: DeepReadonly<Data>;
 };
 
 // HACK: this has to match what comes from the API in the `Error` schema. We put
@@ -29,15 +43,17 @@ export type ErrorResult =
   | {
       type: "error";
       response: Response;
-      data: ErrorBody;
+      data: DeepReadonly<ErrorBody>;
     }
   // JSON parsing or processing errors within the client. Includes raised Error
-  // and response body as a string for debugging.
+  // and response body as a string for debugging. `error`/`text` are client-side
+  // values (not an API payload), so there's nothing to deep-freeze — we just
+  // mark the bindings readonly for consistency with the other variants.
   | {
       type: "client_error";
       response: Response;
-      error: Error;
-      text: string;
+      readonly error: Error;
+      readonly text: string;
     };
 
 export type ApiResult<Data> = ApiSuccess<Data> | ErrorResult;
@@ -85,7 +101,7 @@ export async function handleResponse<Data>(
     return {
       type: "error",
       response,
-      data: respJson as ErrorBody,
+      data: respJson as DeepReadonly<ErrorBody>,
     };
   }
 
@@ -93,7 +109,7 @@ export async function handleResponse<Data>(
   return {
     type: "success",
     response,
-    data: respJson as Data,
+    data: respJson as DeepReadonly<Data>,
   };
 }
 

--- a/oxide-openapi-gen-ts/src/__snapshots__/http-client.ts
+++ b/oxide-openapi-gen-ts/src/__snapshots__/http-client.ts
@@ -8,11 +8,25 @@
 
 import { camelToSnake, processResponseBody, isNotNull } from "./util";
 
+/**
+ * Recursively mark a type readonly. `Date` is left intact (it's a class, not a
+ * plain data object) and arrays become `ReadonlyArray`. Used to make API
+ * response bodies immutable without touching the request-body types, which
+ * share the same underlying schemas but may be mutated while being built.
+ */
+export type DeepReadonly<T> = T extends Date
+  ? T
+  : T extends (infer U)[]
+    ? ReadonlyArray<DeepReadonly<U>>
+    : T extends object
+      ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+      : T;
+
 /** Success responses from the API */
 export type ApiSuccess<Data> = {
   type: "success";
   response: Response;
-  data: Data;
+  data: DeepReadonly<Data>;
 };
 
 // HACK: this has to match what comes from the API in the `Error` schema. We put
@@ -29,15 +43,17 @@ export type ErrorResult =
   | {
       type: "error";
       response: Response;
-      data: ErrorBody;
+      data: DeepReadonly<ErrorBody>;
     }
   // JSON parsing or processing errors within the client. Includes raised Error
-  // and response body as a string for debugging.
+  // and response body as a string for debugging. `error`/`text` are client-side
+  // values (not an API payload), so there's nothing to deep-freeze — we just
+  // mark the bindings readonly for consistency with the other variants.
   | {
       type: "client_error";
       response: Response;
-      error: Error;
-      text: string;
+      readonly error: Error;
+      readonly text: string;
     };
 
 export type ApiResult<Data> = ApiSuccess<Data> | ErrorResult;
@@ -85,7 +101,7 @@ export async function handleResponse<Data>(
     return {
       type: "error",
       response,
-      data: respJson as ErrorBody,
+      data: respJson as DeepReadonly<ErrorBody>,
     };
   }
 
@@ -93,7 +109,7 @@ export async function handleResponse<Data>(
   return {
     type: "success",
     response,
-    data: respJson as Data,
+    data: respJson as DeepReadonly<Data>,
   };
 }
 

--- a/oxide-openapi-gen-ts/src/client/static/deep-readonly.test.ts
+++ b/oxide-openapi-gen-ts/src/client/static/deep-readonly.test.ts
@@ -1,0 +1,68 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { assert, type Equals } from "tsafe";
+import { test } from "vitest";
+import type { ApiSuccess, DeepReadonly, ErrorResult } from "./http-client";
+
+// These are type-level assertions verified by `npm run tsc`; at runtime the
+// `assert` calls are no-ops. Wrapped in a `test` so vitest doesn't complain the
+// file has no tests.
+test("DeepReadonly", () => {
+  // primitives pass through untouched
+  assert<Equals<DeepReadonly<string>, string>>();
+  assert<Equals<DeepReadonly<number>, number>>();
+  assert<Equals<DeepReadonly<null>, null>>();
+
+  // Date is left intact rather than mapped into a readonly object
+  assert<Equals<DeepReadonly<Date>, Date>>();
+
+  // arrays become ReadonlyArray, recursively
+  assert<Equals<DeepReadonly<number[]>, ReadonlyArray<number>>>();
+  assert<
+    Equals<DeepReadonly<{ a: number }[]>, ReadonlyArray<{ readonly a: number }>>
+  >();
+
+  // objects get readonly keys, recursively, and Date/arrays inside are handled
+  type In = { a: number; nested: { b: string }; list: number[]; when: Date };
+  type Out = {
+    readonly a: number;
+    readonly nested: { readonly b: string };
+    readonly list: ReadonlyArray<number>;
+    readonly when: Date;
+  };
+  assert<Equals<DeepReadonly<In>, Out>>();
+});
+
+test("ApiSuccess.data is deeply readonly", () => {
+  const reject = (r: ApiSuccess<{ a: number; list: number[] }>) => {
+    // @ts-expect-error top-level prop is readonly
+    r.data.a = 1;
+    // @ts-expect-error nested array is a ReadonlyArray
+    r.data.list.push(2);
+  };
+  void reject;
+});
+
+test("error response payload is deeply readonly", () => {
+  const reject = (r: Extract<ErrorResult, { type: "error" }>) => {
+    // @ts-expect-error ErrorBody payload is deeply readonly
+    r.data.message = "x";
+  };
+  void reject;
+});
+
+test("client_error bindings are readonly", () => {
+  const reject = (r: Extract<ErrorResult, { type: "client_error" }>) => {
+    // @ts-expect-error binding is readonly
+    r.text = "x";
+    // @ts-expect-error binding is readonly
+    r.error = new Error();
+  };
+  void reject;
+});

--- a/oxide-openapi-gen-ts/src/client/static/http-client.ts
+++ b/oxide-openapi-gen-ts/src/client/static/http-client.ts
@@ -8,11 +8,25 @@
 
 import { camelToSnake, processResponseBody, isNotNull } from "./util";
 
+/**
+ * Recursively mark a type readonly. `Date` is left intact (it's a class, not a
+ * plain data object) and arrays become `ReadonlyArray`. Used to make API
+ * response bodies immutable without touching the request-body types, which
+ * share the same underlying schemas but may be mutated while being built.
+ */
+export type DeepReadonly<T> = T extends Date
+  ? T
+  : T extends (infer U)[]
+    ? ReadonlyArray<DeepReadonly<U>>
+    : T extends object
+      ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+      : T;
+
 /** Success responses from the API */
 export type ApiSuccess<Data> = {
   type: "success";
   response: Response;
-  data: Data;
+  data: DeepReadonly<Data>;
 };
 
 // HACK: this has to match what comes from the API in the `Error` schema. We put
@@ -29,15 +43,17 @@ export type ErrorResult =
   | {
       type: "error";
       response: Response;
-      data: ErrorBody;
+      data: DeepReadonly<ErrorBody>;
     }
   // JSON parsing or processing errors within the client. Includes raised Error
-  // and response body as a string for debugging.
+  // and response body as a string for debugging. `error`/`text` are client-side
+  // values (not an API payload), so there's nothing to deep-freeze — we just
+  // mark the bindings readonly for consistency with the other variants.
   | {
       type: "client_error";
       response: Response;
-      error: Error;
-      text: string;
+      readonly error: Error;
+      readonly text: string;
     };
 
 export type ApiResult<Data> = ApiSuccess<Data> | ErrorResult;
@@ -85,7 +101,7 @@ export async function handleResponse<Data>(
     return {
       type: "error",
       response,
-      data: respJson as ErrorBody,
+      data: respJson as DeepReadonly<ErrorBody>,
     };
   }
 
@@ -93,7 +109,7 @@ export async function handleResponse<Data>(
   return {
     type: "success",
     response,
-    data: respJson as Data,
+    data: respJson as DeepReadonly<Data>,
   };
 }
 


### PR DESCRIPTION
Addresses  #329. 

This PR wraps API response payloads in `DeepReadonly<T>` so they can't be mutated, nested objects and arrays included. Covers both success (`ApiSuccess.data`) and API error (`ErrorResult`'s `ErrorBody`) responses; the client-side `client_error` variant gets `readonly` bindings for consistency.

Applied at the response boundary in `http-client.ts`, so request bodies stay mutable: a shared schema is mutable when you build a request and frozen when it comes back. `Date` is passed through untouched.

I am a bit uncertain if that is what issue 329 wants or is it expected to have the DeepReadonly around the whole type. I went with this approach as this keeps the server's response readonly. 